### PR TITLE
Scrape GitBook with puppeteer

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -21,7 +21,7 @@
     "inquirer": "^9.1.0",
     "minimist-lite": "^2.2.1",
     "node-html-markdown": "^1.2.0",
-    "puppeteer": "^17.1.2"
+    "puppeteer": "^17.1.3"
   },
   "devDependencies": {
     "@types/inquirer": "^9.0.1",

--- a/cli/src/browser.ts
+++ b/cli/src/browser.ts
@@ -1,0 +1,24 @@
+import { launch } from "puppeteer";
+
+export async function startBrowser() {
+  try {
+    return await launch({
+      headless: true,
+      ignoreHTTPSErrors: true,
+    });
+  } catch (err) {
+    console.log("Could not create a browser instance: ", err);
+    process.exit(1);
+  }
+}
+
+export async function getHtmlWithPuppeteer(href: string) {
+  const browser = await startBrowser();
+  const page = await browser.newPage();
+  await page.goto(href, {
+    waitUntil: "networkidle2",
+  });
+  const html = await page.content();
+  browser.close();
+  return html;
+}

--- a/cli/src/scraping/downloadAllImages.ts
+++ b/cli/src/scraping/downloadAllImages.ts
@@ -34,6 +34,15 @@ export default async function downloadAllImages(
             srcSplit.slice(0, -1).join(".") + "." + fileExtension.split("#")[0]
           );
         })
+        .map((src: string) => {
+          // Some frameworks add metadata after the file extension with
+          // a question mark before it, we need to remove that.
+          const srcSplit = src.split(".");
+          const fileExtension = srcSplit[srcSplit.length - 1];
+          return (
+            srcSplit.slice(0, -1).join(".") + "." + fileExtension.split("?")[0]
+          );
+        })
     ),
   ];
 

--- a/cli/src/scraping/downloadAllImages.ts
+++ b/cli/src/scraping/downloadAllImages.ts
@@ -26,22 +26,7 @@ export default async function downloadAllImages(
           src.startsWith("http") ? src : new URL(src, origin).href
         )
         .map((src: string) => {
-          // Some frameworks add metadata after the file extension with
-          // a hashtag before it, we need to remove that.
-          const srcSplit = src.split(".");
-          const fileExtension = srcSplit[srcSplit.length - 1];
-          return (
-            srcSplit.slice(0, -1).join(".") + "." + fileExtension.split("#")[0]
-          );
-        })
-        .map((src: string) => {
-          // Some frameworks add metadata after the file extension with
-          // a question mark before it, we need to remove that.
-          const srcSplit = src.split(".");
-          const fileExtension = srcSplit[srcSplit.length - 1];
-          return (
-            srcSplit.slice(0, -1).join(".") + "." + fileExtension.split("?")[0]
-          );
+          return removeFromExtension(src, "#");
         })
     ),
   ];
@@ -49,7 +34,7 @@ export default async function downloadAllImages(
   // Wait to all images to download before continuing
   await Promise.all(
     imageSrcs.map((imageSrc: string) => {
-      const fileName = path.basename(imageSrc);
+      const fileName = removeFromExtension(path.basename(imageSrc), "?");
 
       if (!fileName) {
         console.error("Invalid image path " + imageSrc);
@@ -70,5 +55,17 @@ export default async function downloadAllImages(
           }
         });
     })
+  );
+}
+
+function removeFromExtension(src, dividerSymbol) {
+  // Some frameworks add metadata after the file extension with
+  // a question mark before it, we need to remove that.
+  const srcSplit = src.split(".");
+  const fileExtension = srcSplit[srcSplit.length - 1];
+  return (
+    srcSplit.slice(0, -1).join(".") +
+    "." +
+    fileExtension.split(dividerSymbol)[0]
   );
 }

--- a/cli/src/scraping/scrapeGettingFileNameFromUrl.ts
+++ b/cli/src/scraping/scrapeGettingFileNameFromUrl.ts
@@ -1,5 +1,6 @@
 import path from "path";
 import axios from "axios";
+import { getHtmlWithPuppeteer } from "../browser.js";
 import { createPage } from "../util.js";
 
 export async function scrapeGettingFileNameFromUrl(
@@ -16,6 +17,7 @@ export async function scrapeGettingFileNameFromUrl(
     description?: string;
     markdown?: string;
   }>,
+  puppeteer = false,
   baseToRemove?: string
 ) {
   // Skip scraping external links
@@ -37,8 +39,15 @@ export async function scrapeGettingFileNameFromUrl(
   const imageBaseDir = path.join(cliDir, "images", folders);
 
   // Scrape each page separately
-  const res = await axios.default.get(new URL(pathname, origin).href);
-  const html = res.data;
+  const href = new URL(pathname, origin).href;
+  let html: string;
+  if (puppeteer) {
+    html = await getHtmlWithPuppeteer(href);
+  } else {
+    const res = await axios.default.get(href);
+    html = res.data;
+  }
+
   const { title, description, markdown } = await scrapePageFunc(
     html,
     origin,

--- a/cli/src/scraping/site-scrapers/scrapeDocusaurusSection.ts
+++ b/cli/src/scraping/site-scrapers/scrapeDocusaurusSection.ts
@@ -66,6 +66,7 @@ export async function scrapeDocusaurusSection(
               pathname,
               overwrite,
               scrapeDocusaurusPage,
+              false,
               "/docs"
             )
           )

--- a/cli/src/scraping/site-scrapers/scrapeGitBookPage.ts
+++ b/cli/src/scraping/site-scrapers/scrapeGitBookPage.ts
@@ -1,6 +1,6 @@
-import axios from "axios";
 import cheerio from "cheerio";
 import { NodeHtmlMarkdown } from "node-html-markdown";
+import downloadAllImages from "../downloadAllImages.js";
 
 export async function scrapeGitBookPage(
   html: string,
@@ -20,9 +20,7 @@ export async function scrapeGitBookPage(
   const content = $('[data-testid="page.contentEditor"]').first();
   const contentHtml = $.html(content);
 
-  // TO DO: GitBook doesn't have the images in the original HTML,
-  // they are added with JavaScript after the page loads.
-  // await downloadAllImages($, content, origin, imageBaseDir);
+  await downloadAllImages($, content, origin, imageBaseDir);
 
   const nhm = new NodeHtmlMarkdown();
   let markdown = nhm.translate(contentHtml);

--- a/cli/src/scraping/site-scrapers/scrapeGitBookSection.ts
+++ b/cli/src/scraping/site-scrapers/scrapeGitBookSection.ts
@@ -18,7 +18,7 @@ export async function scrapeGitBookSection(
     'div[data-testid="page.desktopTableOfContents"] > div > div:first-child'
   )
     .children()
-    .eq(1)
+    .first()
     .children()
     .first()
     .children();
@@ -69,33 +69,37 @@ export async function scrapeGitBookSection(
     })
     .filter((pathname: string) => !allNavPathnames.includes(pathname));
 
-  const sitemapPathnamesForConfig = await Promise.all(
-    sitemapPaths.map(
-      async (pathname: string) =>
-        await scrapeGettingFileNameFromUrl(
-          cliDir,
-          origin,
-          pathname,
-          overwrite,
-          scrapeGitBookPage
-        )
-    )
-  );
+  const sitemapPathnamesForConfig = [];
+  for (const pathname of sitemapPaths) {
+    sitemapPathnamesForConfig.push(
+      await scrapeGettingFileNameFromUrl(
+        cliDir,
+        origin,
+        pathname,
+        overwrite,
+        scrapeGitBookPage,
+        true
+      )
+    );
+  }
 
   // Scrape each link in the navigation.
   const groupsConfigCleanPaths = await Promise.all(
     groupsConfig.map(async (groupConfig) => {
-      groupConfig.pages = await Promise.all(
-        groupConfig.pages.map(async (pathname: string) =>
-          scrapeGettingFileNameFromUrl(
+      const newPages = [];
+      for (const pathname of groupConfig.pages) {
+        newPages.push(
+          await scrapeGettingFileNameFromUrl(
             cliDir,
             origin,
             pathname,
             overwrite,
-            scrapeGitBookPage
+            scrapeGitBookPage,
+            true
           )
-        )
-      );
+        );
+      }
+      groupConfig.pages = newPages;
       return groupConfig;
     })
   );

--- a/cli/src/scraping/site-scrapers/scrapeReadMeSection.ts
+++ b/cli/src/scraping/site-scrapers/scrapeReadMeSection.ts
@@ -68,6 +68,7 @@ export async function scrapeReadMeSection(
             pathname,
             overwrite,
             scrapeReadMePage,
+            false,
             "/docs"
           )
         )


### PR DESCRIPTION
# Summary

GitBook nested navigation adds links with JavaScript. Images are also added in with JavaScript after the page loads.

Using Puppeteer lets us open all the menus by simulating clicking their toggles. Puppeteer also scrapes individual pages so we can wait for all network calls to finish before scraping -- allowing us to download the images.

# Test Plan

Run `scrape-page` on https://docs.gitbook.com/getting-started/gitbook-app

Run `scrape-section` on https://docs.gitbook.com/

You should see images downloaded when using both commands. You should also see pages in nested navigation scraped.