### PR TITLE
Add setup for endmatter

### DIFF
--- a/client/next.config.js
+++ b/client/next.config.js
@@ -15,6 +15,7 @@ import withApiComponents from './rehype/withApiComponents.js';
 import mintConfig from './src/config.json' assert { type: 'json' };
 import withSyntaxHighlighting from './rehype/withSyntaxHighlighting.js';
 import withLayouts from './rehype/withLayouts.js';
+import { potentiallyRemoveEndMatter } from './prebuild/injectNav.js';
 
 const withBundleAnalyzer = BundleAnalyzer({
   enabled: process.env.ANALYZE === 'true',
@@ -138,7 +139,7 @@ export default withSentryConfig(
           },
           createLoader(function (source) {
             const { body } = frontMatter(source);
-            return body;
+            return potentiallyRemoveEndMatter(body);
           }),
         ],
       });

--- a/client/prebuild/injectNav.js
+++ b/client/prebuild/injectNav.js
@@ -9,12 +9,48 @@ import { slugToTitle } from './slugToTitle.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+// End matter is front matter, but at the end
+const getIndexOfEndMatter = (fileContents) => {
+  const frontMatters = fileContents.match(/---\n(title:.+\n|description:.+\n|sidebarTitle:.+\n|api:.+\n|openapi:.+\n)+---$/m);
+  if (frontMatters) {
+    return fileContents.indexOf(frontMatters[0]);
+  }
+
+  return -1;
+}
+
+export const potentiallyRemoveEndMatter = (fileContents) => {
+  const endMatterIndex = getIndexOfEndMatter(fileContents);
+
+  if (endMatterIndex === -1) {
+    return fileContents;
+  }
+
+  return fileContents.substring(0, endMatterIndex);
+}
+
+const getMetadata = (fileContents) => {
+  const { data } = matter(fileContents);
+
+  if (Object.keys(data).length > 0) {
+    return data;
+  }
+
+  const startIndex =  getIndexOfEndMatter(fileContents);
+  if (startIndex === -1) {
+    return {}
+  }
+
+  const fileContentFromFrontMatter = fileContents.substring(startIndex);
+  const { data: nonTopFrontMatter } = matter(fileContentFromFrontMatter);
+  return nonTopFrontMatter;
+}
+
 export const createPage = (path, content, openApiObj) => {
   const slug = path.replace(/\.mdx?$/, '');
   let defaultTitle = slugToTitle(slug);
   const fileContents = Buffer.from(content).toString();
-  const { data } = matter(fileContents);
-  const metadata = data;
+  const metadata = getMetadata(fileContents);
   // Append data from OpenAPI if it exists
   const { title, description } = getOpenApiTitleAndDescription(openApiObj, metadata?.openapi);
   if (title) {

--- a/client/src/css/utilities.css
+++ b/client/src/css/utilities.css
@@ -37,3 +37,7 @@
 .changing-theme * {
   transition: none !important;
 }
+
+input[type='checkbox'] {
+  margin: 0 !important;
+}


### PR DESCRIPTION
# Summary
This PR adds the setup for "end-matter" (frontmatter but available at the end). It does the following:
- If there is frontmatter syntax at the end of the file, use that and remove it from view

# Test Plan
- All previews look normal for existing docs
- Title and description should be customized for Venice