### PR TITLE
Use downloaded image path instead of original href

### DIFF
--- a/cli/src/scraping/downloadAllImages.ts
+++ b/cli/src/scraping/downloadAllImages.ts
@@ -6,7 +6,7 @@ export default async function downloadAllImages(
   $: any,
   content: any,
   origin: string,
-  baseDir?: string
+  baseDir: string
 ) {
   if (!baseDir) {
     console.debug("Skipping image downloading");

--- a/cli/src/scraping/downloadAllImages.ts
+++ b/cli/src/scraping/downloadAllImages.ts
@@ -6,7 +6,8 @@ export default async function downloadAllImages(
   $: any,
   content: any,
   origin: string,
-  baseDir: string
+  baseDir: string,
+  modifyFileName?: any
 ) {
   if (!baseDir) {
     console.debug("Skipping image downloading");
@@ -21,29 +22,30 @@ export default async function downloadAllImages(
         .find("img[src]")
         .map((i, image) => $(image).attr("src"))
         .toArray()
-        .map((src: string) =>
-          // Add origin if the image tags are using relative sources
-          src.startsWith("http") ? src : new URL(src, origin).href
-        )
-        .map((src: string) => {
-          return removeFromExtension(src, "#");
-        })
     ),
   ];
 
   // Wait to all images to download before continuing
-  await Promise.all(
-    imageSrcs.map((imageSrc: string) => {
-      const fileName = removeFromExtension(path.basename(imageSrc), "?");
+  const origToNewArray = await Promise.all(
+    imageSrcs.map(async (origImageSrc: string) => {
+      // Add origin if the image tags are using relative sources
+      const imageHref = origImageSrc.startsWith("http")
+        ? origImageSrc
+        : new URL(origImageSrc, origin).href;
+
+      let fileName = removeFromExtension(path.basename(imageHref), ["?", "#"]);
+      if (modifyFileName) {
+        fileName = modifyFileName(fileName);
+      }
 
       if (!fileName) {
-        console.error("Invalid image path " + imageSrc);
+        console.error("Invalid image path " + imageHref);
         return;
       }
 
       const writePath = path.join(baseDir, fileName);
 
-      return downloadImage(imageSrc, writePath)
+      await downloadImage(imageHref, writePath)
         .then(() => {
           console.log("🖼️ - " + writePath);
         })
@@ -54,18 +56,27 @@ export default async function downloadAllImages(
             console.error(e);
           }
         });
+
+      return { [origImageSrc]: writePath };
     })
+  );
+
+  return origToNewArray.reduce(
+    (result, current) => Object.assign(result, current),
+    {}
   );
 }
 
-function removeFromExtension(src, dividerSymbol) {
-  // Some frameworks add metadata after the file extension with
-  // a question mark before it, we need to remove that.
-  const srcSplit = src.split(".");
-  const fileExtension = srcSplit[srcSplit.length - 1];
-  return (
-    srcSplit.slice(0, -1).join(".") +
-    "." +
-    fileExtension.split(dividerSymbol)[0]
-  );
+function removeFromExtension(src: string, dividerSymbols: string[]) {
+  dividerSymbols.forEach((dividerSymbol) => {
+    // Some frameworks add metadata after the file extension with
+    // a question mark before it, we need to remove that.
+    const srcSplit = src.split(".");
+    const fileExtension = srcSplit[srcSplit.length - 1];
+    src =
+      srcSplit.slice(0, -1).join(".") +
+      "." +
+      fileExtension.split(dividerSymbol)[0];
+  });
+  return src;
 }

--- a/cli/src/scraping/replaceImagePaths.ts
+++ b/cli/src/scraping/replaceImagePaths.ts
@@ -1,0 +1,21 @@
+export default function replaceImagePaths(
+  origToWritePath: object,
+  cliDir: string,
+  markdown: string
+) {
+  if (origToWritePath == null) {
+    return markdown;
+  }
+
+  // Change image paths to use the downloaded locations
+  for (const [origHref, writePath] of Object.entries(origToWritePath)) {
+    // Use relative paths within the folder we are in
+    if (writePath.startsWith(cliDir)) {
+      markdown = markdown.replaceAll(origHref, writePath.slice(cliDir.length));
+    } else {
+      markdown = markdown.replaceAll(origHref, writePath);
+    }
+  }
+
+  return markdown;
+}

--- a/cli/src/scraping/scrapeGettingFileNameFromUrl.ts
+++ b/cli/src/scraping/scrapeGettingFileNameFromUrl.ts
@@ -11,7 +11,7 @@ export async function scrapeGettingFileNameFromUrl(
   scrapePageFunc: (
     html: string,
     origin: string,
-    imageBaseDir?: string
+    imageBaseDir: string
   ) => Promise<{
     title?: string;
     description?: string;

--- a/cli/src/scraping/scrapeGettingFileNameFromUrl.ts
+++ b/cli/src/scraping/scrapeGettingFileNameFromUrl.ts
@@ -11,6 +11,7 @@ export async function scrapeGettingFileNameFromUrl(
   scrapePageFunc: (
     html: string,
     origin: string,
+    cliDir: string,
     imageBaseDir: string
   ) => Promise<{
     title?: string;
@@ -51,6 +52,7 @@ export async function scrapeGettingFileNameFromUrl(
   const { title, description, markdown } = await scrapePageFunc(
     html,
     origin,
+    cliDir,
     imageBaseDir
   );
 

--- a/cli/src/scraping/scrapePage.ts
+++ b/cli/src/scraping/scrapePage.ts
@@ -5,6 +5,7 @@ export async function scrapePage(
   scrapeFunc: (
     html: string,
     origin: string,
+    cliDir: string,
     imageBaseDir: string
   ) => Promise<any>,
   href: string,
@@ -16,6 +17,7 @@ export async function scrapePage(
   const { title, description, markdown } = await scrapeFunc(
     html,
     origin,
+    process.cwd(),
     imageBaseDir
   );
   createPage(title, description, markdown, overwrite, process.cwd());

--- a/cli/src/scraping/scrapePage.ts
+++ b/cli/src/scraping/scrapePage.ts
@@ -5,7 +5,7 @@ export async function scrapePage(
   scrapeFunc: (
     html: string,
     origin: string,
-    imageBaseDir?: string
+    imageBaseDir: string
   ) => Promise<any>,
   href: string,
   html: string,

--- a/cli/src/scraping/site-scrapers/scrapeDocusaurusPage.ts
+++ b/cli/src/scraping/site-scrapers/scrapeDocusaurusPage.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import cheerio from "cheerio";
 import { NodeHtmlMarkdown } from "node-html-markdown";
 import downloadAllImages from "../downloadAllImages.js";
@@ -6,7 +5,7 @@ import downloadAllImages from "../downloadAllImages.js";
 export async function scrapeDocusaurusPage(
   html: string,
   origin: string,
-  imageBaseDir?: string
+  imageBaseDir: string
 ) {
   const $ = cheerio.load(html);
 

--- a/cli/src/scraping/site-scrapers/scrapeDocusaurusPage.ts
+++ b/cli/src/scraping/site-scrapers/scrapeDocusaurusPage.ts
@@ -1,10 +1,12 @@
 import cheerio from "cheerio";
 import { NodeHtmlMarkdown } from "node-html-markdown";
 import downloadAllImages from "../downloadAllImages.js";
+import replaceImagePaths from "../replaceImagePaths.js";
 
 export async function scrapeDocusaurusPage(
   html: string,
   origin: string,
+  cliDir: string,
   imageBaseDir: string
 ) {
   const $ = cheerio.load(html);
@@ -22,7 +24,12 @@ export async function scrapeDocusaurusPage(
   // Do not include title in the content when we insert it in our metadata
   titleComponent.remove();
 
-  await downloadAllImages($, content, origin, imageBaseDir);
+  const origToWritePath = await downloadAllImages(
+    $,
+    content,
+    origin,
+    imageBaseDir
+  );
 
   const contentHtml = content.html();
 
@@ -53,6 +60,8 @@ export async function scrapeDocusaurusPage(
 
   // Mintlify doesn't support bolded headers, remove the asterisks
   markdown = markdown.replace(/(\n#+) \*\*(.*)\*\*\n/g, "$1 $2\n");
+
+  markdown = replaceImagePaths(origToWritePath, cliDir, markdown);
 
   return { title, description, markdown };
 }

--- a/cli/src/scraping/site-scrapers/scrapeDocusaurusSection.ts
+++ b/cli/src/scraping/site-scrapers/scrapeDocusaurusSection.ts
@@ -1,8 +1,6 @@
-import axios from "axios";
 import cheerio from "cheerio";
 import { scrapeGettingFileNameFromUrl } from "../scrapeGettingFileNameFromUrl.js";
 import { scrapeDocusaurusPage } from "./scrapeDocusaurusPage.js";
-import { getOrigin } from "../../util.js";
 
 export async function scrapeDocusaurusSection(
   html: string,

--- a/cli/src/scraping/site-scrapers/scrapeGitBookPage.ts
+++ b/cli/src/scraping/site-scrapers/scrapeGitBookPage.ts
@@ -5,7 +5,7 @@ import downloadAllImages from "../downloadAllImages.js";
 export async function scrapeGitBookPage(
   html: string,
   origin: string,
-  imageBaseDir?: string
+  imageBaseDir: string
 ) {
   const $ = cheerio.load(html);
 

--- a/cli/src/scraping/site-scrapers/scrapeGitBookPage.ts
+++ b/cli/src/scraping/site-scrapers/scrapeGitBookPage.ts
@@ -1,10 +1,12 @@
 import cheerio from "cheerio";
 import { NodeHtmlMarkdown } from "node-html-markdown";
 import downloadAllImages from "../downloadAllImages.js";
+import replaceImagePaths from "../replaceImagePaths.js";
 
 export async function scrapeGitBookPage(
   html: string,
   origin: string,
+  cliDir: string,
   imageBaseDir: string
 ) {
   const $ = cheerio.load(html);
@@ -20,7 +22,18 @@ export async function scrapeGitBookPage(
   const content = $('[data-testid="page.contentEditor"]').first();
   const contentHtml = $.html(content);
 
-  await downloadAllImages($, content, origin, imageBaseDir);
+  const modifyFileName = (fileName) =>
+    // Remove GitBook metadata from the start
+    // The first four %2F split metadata fields. Remaining ones are part of the file name.
+    fileName.split("%2F").slice(4).join("%2F");
+
+  const origToWritePath = await downloadAllImages(
+    $,
+    content,
+    origin,
+    imageBaseDir,
+    modifyFileName
+  );
 
   const nhm = new NodeHtmlMarkdown();
   let markdown = nhm.translate(contentHtml);
@@ -36,6 +49,8 @@ export async function scrapeGitBookPage(
 
   // Mintlify doesn't support bolded headers, remove the asterisks
   markdown = markdown.replace(/(\n#+) \*\*(.*)\*\*\n/g, "$1 $2\n");
+
+  markdown = replaceImagePaths(origToWritePath, cliDir, markdown);
 
   return { title, description, markdown };
 }

--- a/cli/src/scraping/site-scrapers/scrapeGitBookSection.ts
+++ b/cli/src/scraping/site-scrapers/scrapeGitBookSection.ts
@@ -1,9 +1,7 @@
-import axios from "axios";
 import cheerio from "cheerio";
 import { scrapeGettingFileNameFromUrl } from "../scrapeGettingFileNameFromUrl.js";
 import { getSitemapLinks } from "../getSitemapLinks.js";
 import { scrapeGitBookPage } from "./scrapeGitBookPage.js";
-import { getOrigin } from "../../util.js";
 
 export async function scrapeGitBookSection(
   html: string,

--- a/cli/src/scraping/site-scrapers/scrapeReadMePage.ts
+++ b/cli/src/scraping/site-scrapers/scrapeReadMePage.ts
@@ -1,10 +1,12 @@
 import cheerio from "cheerio";
 import { NodeHtmlMarkdown } from "node-html-markdown";
 import downloadAllImages from "../downloadAllImages.js";
+import replaceImagePaths from "../replaceImagePaths.js";
 
 export async function scrapeReadMePage(
   html: string,
   origin: string,
+  cliDir: string,
   imageBaseDir: string
 ) {
   const $ = cheerio.load(html);
@@ -22,7 +24,12 @@ export async function scrapeReadMePage(
   }
   const contentHtml = content.html();
 
-  await downloadAllImages($, content, origin, imageBaseDir);
+  const origToWritePath = await downloadAllImages(
+    $,
+    content,
+    origin,
+    imageBaseDir
+  );
 
   const nhm = new NodeHtmlMarkdown();
   let markdown = nhm.translate(contentHtml);
@@ -41,6 +48,8 @@ export async function scrapeReadMePage(
 
   // Mintlify doesn't support bolded headers, remove the asterisks
   markdown = markdown.replace(/(\n#+) \*\*(.*)\*\*\n/g, "$1 $2\n");
+
+  markdown = replaceImagePaths(origToWritePath, cliDir, markdown);
 
   return { title, description, markdown };
 }

--- a/cli/src/scraping/site-scrapers/scrapeReadMePage.ts
+++ b/cli/src/scraping/site-scrapers/scrapeReadMePage.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import cheerio from "cheerio";
 import { NodeHtmlMarkdown } from "node-html-markdown";
 import downloadAllImages from "../downloadAllImages.js";
@@ -6,7 +5,7 @@ import downloadAllImages from "../downloadAllImages.js";
 export async function scrapeReadMePage(
   html: string,
   origin: string,
-  imageBaseDir?: string
+  imageBaseDir: string
 ) {
   const $ = cheerio.load(html);
 

--- a/cli/src/scraping/site-scrapers/scrapeReadMeSection.ts
+++ b/cli/src/scraping/site-scrapers/scrapeReadMeSection.ts
@@ -1,7 +1,5 @@
-import axios from "axios";
 import cheerio from "cheerio";
 import { scrapeReadMePage } from "./scrapeReadMePage.js";
-import { getOrigin } from "../../util.js";
 import { scrapeGettingFileNameFromUrl } from "../scrapeGettingFileNameFromUrl.js";
 
 export async function scrapeReadMeSection(

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "node16",
     "moduleResolution": "node16",
     "target": "es2017",
-    "lib": ["es2016", "dom"],
+    "lib": ["es2016", "dom", "ES2021.String"],
     "sourceMap": true,
     "outDir": "bin",
     "baseUrl": ".",


### PR DESCRIPTION
# Summary

Turns image hrefs like `https://2775338190-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FNkEGS7hzeqa35sMXQZ4X%2Fuploads%2Fgit-blob-0a55f6175142952bbc7c3f14408ca1cabbb33abf%2FGit%20Sync%20%E2%80%93%20Provider.png?alt=media&token=94dfa716-9a2c-4657-a551-60fa3c2fd777` into `/images/getting-started/git-sync/Git%20Sync%20%E2%80%93%20Provider.png`

Before, scraped images were using the original image paths even though images were downloaded.

# Test Plan

Run `scrape-page` and `scrape-section` on https://docs.gitbook.com, https://docs.readme.com, and https://docusaurus.io/docs.