### PR TITLE
Generate nested navigation when scraping GitBook and ReadMe

### DIFF
--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -101,12 +101,15 @@ export type Config = {
   };
 };
 
-export const findFirstPage = (group: Navigation, target: string): Page | undefined => {
+export const findFirstNavigationEntry = (
+  group: Navigation,
+  target: string
+): NavigationEntry | undefined => {
   return group.pages.find((page) => {
     if (typeof page === 'string') {
       return page.includes(target);
     } else {
-      return findFirstPage(page, target);
+      return findFirstNavigationEntry(page, target);
     }
   });
 };

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -10,11 +10,11 @@ import configJSON from './config.json';
 
 export const config: Config = configJSON;
 
-export type Page = string | Navigation;
+export type NavigationEntry = string | Navigation;
 
 export type Navigation = {
   group: string;
-  pages: Page[];
+  pages: NavigationEntry[];
 };
 
 type Logo = string | { light: string; dark: string; href?: string };

--- a/client/src/layouts/SidebarLayout.tsx
+++ b/client/src/layouts/SidebarLayout.tsx
@@ -13,7 +13,7 @@ import { PageContext, Group, Groups, GroupPage, isGroup } from '@/nav';
 import { extractMethodAndEndpoint } from '@/utils/api';
 import { getMethodDotsColor } from '@/utils/brands';
 
-import { config, findFirstPage } from '../config';
+import { config, findFirstNavigationEntry } from '../config';
 import { StyledTopLevelLink, TopLevelLink } from '../ui/TopLevelLink';
 import isPathInGroupPages from './isPathInGroupPages';
 
@@ -300,7 +300,7 @@ function TopLevelNav({ mobile }: { mobile: boolean }) {
               href = anchor.url;
             } else {
               config.navigation?.every((nav) => {
-                const page = findFirstPage(nav, `${anchor.url}/`);
+                const page = findFirstNavigationEntry(nav, `${anchor.url}/`);
                 if (page) {
                   if (typeof page === 'string') {
                     href = `/${page}`;

--- a/packages/mintlify/src/navigation.ts
+++ b/packages/mintlify/src/navigation.ts
@@ -1,0 +1,12 @@
+export type NavigationEntry = string | Navigation;
+
+export type Navigation = {
+  group: string;
+  pages: NavigationEntry[];
+};
+
+export function isNavigation(
+  navEntry: NavigationEntry
+): navEntry is Navigation {
+  return typeof navEntry !== "string";
+}

--- a/packages/mintlify/src/scraping/getSitemapLinks.ts
+++ b/packages/mintlify/src/scraping/getSitemapLinks.ts
@@ -1,5 +1,7 @@
 import axios from "axios";
 
+// Not in use.
+// Gets all links in a sitemap.
 export const getSitemapLinks = async (url: URL) => {
   const hostname = url.hostname.replace(".", "\\.");
   const regex = new RegExp(`https?:\/\/${hostname}.+?(?=<\/loc>)`, "gmi");

--- a/packages/mintlify/src/scraping/scrapeFileGettingFileNameFromUrl.ts
+++ b/packages/mintlify/src/scraping/scrapeFileGettingFileNameFromUrl.ts
@@ -1,0 +1,81 @@
+import path from "path";
+import axios from "axios";
+import { getHtmlWithPuppeteer } from "../browser.js";
+import { createPage } from "../util.js";
+
+export async function scrapeFileGettingFileNameFromUrl(
+  pathname: string,
+  cliDir: string,
+  origin: string,
+  overwrite: boolean,
+  scrapePageFunc: (
+    html: string,
+    origin: string,
+    cliDir: string,
+    imageBaseDir: string
+  ) => Promise<{
+    title?: string;
+    description?: string;
+    markdown?: string;
+  }>,
+  puppeteer = false,
+  baseToRemove?: string
+) {
+  // Skip scraping external links
+  if (pathname.startsWith("https://") || pathname.startsWith("http://")) {
+    return pathname;
+  }
+
+  // Removes file name from the end
+  const splitSubpath = pathname.split("/");
+  let folders = splitSubpath.slice(0, splitSubpath.length - 1).join("/");
+
+  // Remove base dir if passed in
+  if (baseToRemove && folders.startsWith(baseToRemove)) {
+    folders = folders.replace(baseToRemove, "");
+  }
+
+  // TO DO: Improve this by putting each page's images in a separate
+  // folder named after the title of the page.
+  const imageBaseDir = path.join(cliDir, "images", folders);
+
+  // Scrape each page separately
+  const href = new URL(pathname, origin).href;
+  let html: string;
+  if (puppeteer) {
+    html = await getHtmlWithPuppeteer(href);
+  } else {
+    const res = await axios.default.get(href);
+    html = res.data;
+  }
+
+  const { title, description, markdown } = await scrapePageFunc(
+    html,
+    origin,
+    cliDir,
+    imageBaseDir
+  );
+
+  // Check if page didn't have content
+  if (!title && !markdown) {
+    return undefined;
+  }
+
+  const newFileLocation = folders ? path.join(cliDir, folders) : cliDir;
+
+  // Default to introduction.mdx if we encountered index.html
+  const fileName = splitSubpath[splitSubpath.length - 1] || "introduction";
+
+  // Will create subfolders as needed
+  createPage(
+    title,
+    description,
+    markdown,
+    overwrite,
+    newFileLocation,
+    fileName
+  );
+
+  // Removes first slash if we are in a folder, Mintlify doesn't need it
+  return folders ? path.join(folders, fileName).substring(1) : fileName;
+}

--- a/packages/mintlify/src/scraping/site-scrapers/getLinksRecursively.ts
+++ b/packages/mintlify/src/scraping/site-scrapers/getLinksRecursively.ts
@@ -1,0 +1,40 @@
+// Used by GitBook and ReadMe section scrapers
+export default function getLinksRecursively(linkSections: any, $: any) {
+  if (linkSections == null || linkSections.length === 0) {
+    return [];
+  }
+
+  return linkSections
+    .map((i, s) => {
+      const subsection = $(s);
+      const link = subsection.children().first();
+
+      const linkHref = link.attr("href");
+
+      // Skip missing links. For example, GitBook uses
+      // empty divs are used for styling a line beside the nav.
+      // Skip external links until Mintlify supports them
+      if (
+        !linkHref ||
+        linkHref.startsWith("https://") ||
+        linkHref.startsWith("http://")
+      ) {
+        return undefined;
+      }
+
+      const childLinks = subsection.children().eq(1).children();
+
+      if (childLinks.length > 0) {
+        // Put the section link in the list of pages.
+        // When we support the section itself being a link we should update this
+        return {
+          group: link.text(),
+          pages: [linkHref, ...getLinksRecursively(childLinks, $)],
+        };
+      }
+
+      return linkHref;
+    })
+    .toArray()
+    .filter(Boolean);
+}

--- a/packages/mintlify/src/scraping/site-scrapers/scrapeDocusaurusSection.ts
+++ b/packages/mintlify/src/scraping/site-scrapers/scrapeDocusaurusSection.ts
@@ -59,9 +59,9 @@ export async function scrapeDocusaurusSection(
             // Docusaurus requires a directory on all sections wheras we use root.
             // /docs is their default directory so we remove it
             scrapeGettingFileNameFromUrl(
+              pathname,
               cliDir,
               origin,
-              pathname,
               overwrite,
               scrapeDocusaurusPage,
               false,

--- a/packages/mintlify/src/scraping/site-scrapers/scrapeGitBookSection.ts
+++ b/packages/mintlify/src/scraping/site-scrapers/scrapeGitBookSection.ts
@@ -1,7 +1,8 @@
 import cheerio from "cheerio";
 import { scrapeGettingFileNameFromUrl } from "../scrapeGettingFileNameFromUrl.js";
-import { getSitemapLinks } from "../getSitemapLinks.js";
 import { scrapeGitBookPage } from "./scrapeGitBookPage.js";
+import getLinksRecursively from "./getLinksRecursively.js";
+import { NavigationEntry } from "../../navigation.js";
 
 export async function scrapeGitBookSection(
   html: string,
@@ -22,95 +23,42 @@ export async function scrapeGitBookSection(
     .children();
 
   // Get all links per group
-  let allNavPathnames = [];
   const groupsConfig = navigationSections
-    .map((i, section) => {
+    .map((i, s) => {
+      const section = $(s);
       const sectionTitle = $(section)
         .find('div > div[dir="auto"]')
         .first()
         .text();
 
-      const linkPaths = $(section)
-        .find("a[href]")
-        .map((i, link) => {
-          const linkHref = $(link).attr("href");
+      // Only present if the nested navigation is not in a group
+      const firstLink = section.children().eq(0);
+      const firstHref = firstLink.attr("href");
 
-          // Skip external links until Mintlify supports them
-          if (
-            linkHref.startsWith("https://") ||
-            linkHref.startsWith("http://")
-          ) {
-            return undefined;
-          }
+      const linkSections = section.children().eq(1).children();
+      const pages = getLinksRecursively(linkSections, $);
 
-          return linkHref;
-        })
-        .toArray();
-
-      allNavPathnames = allNavPathnames.concat(linkPaths);
-
-      // Follows the same structure as mint.json
       return {
-        group: sectionTitle,
-        pages: linkPaths,
+        group: sectionTitle || firstLink?.text(),
+        pages: firstHref ? [firstHref, ...pages] : pages,
       };
     })
-    .toArray();
-
-  // Scrape every link not in the navigation. Nested docs
-  // don't show up in navigation without clicking buttons,
-  // so this lets us download the files for the user to add
-  // manually to mint.json.
-  const sitemapPaths = (await getSitemapLinks(new URL("sitemap.xml", origin)))
-    .map((sitemapLinks: string) => {
-      return new URL(sitemapLinks).pathname;
-    })
-    .filter((pathname: string) => !allNavPathnames.includes(pathname));
-
-  const sitemapPathnamesForConfig = [];
-  for (const pathname of sitemapPaths) {
-    sitemapPathnamesForConfig.push(
-      await scrapeGettingFileNameFromUrl(
-        cliDir,
-        origin,
-        pathname,
-        overwrite,
-        scrapeGitBookPage,
-        true
-      )
-    );
-  }
+    .toArray()
+    .filter(Boolean);
 
   // Scrape each link in the navigation.
   const groupsConfigCleanPaths = await Promise.all(
-    groupsConfig.map(async (groupConfig) => {
-      const newPages = [];
-      for (const pathname of groupConfig.pages) {
-        newPages.push(
-          await scrapeGettingFileNameFromUrl(
-            cliDir,
-            origin,
-            pathname,
-            overwrite,
-            scrapeGitBookPage,
-            true
-          )
-        );
-      }
-      groupConfig.pages = newPages;
-      return groupConfig;
+    groupsConfig.map(async (navEntry: NavigationEntry) => {
+      return await scrapeGettingFileNameFromUrl(
+        navEntry,
+        cliDir,
+        origin,
+        overwrite,
+        scrapeGitBookPage,
+        true
+      );
     })
   );
-
-  if (sitemapPathnamesForConfig.length > 0) {
-    return groupsConfigCleanPaths.concat([
-      {
-        group:
-          "ATTENTION! WE CANNOT DETECT GROUPS FOR NESTED DOCS. PLEASE MOVE THEM INTO THEIR ORIGINAL GROUPS.",
-        pages: sitemapPathnamesForConfig,
-      },
-    ]);
-  }
 
   return groupsConfigCleanPaths;
 }


### PR DESCRIPTION
# Summary

Navigation was flattened before in the `mint.json` the CLI generates. This correctly generates nested menus when they are being used.

# Test Plan

Run `mintlify scrape-section https://docs.readme.com/` and `mintlify scrape-section https://docs.gitbook.com/` in empty folders.