### PR TITLE
Add enums

### DIFF
--- a/client/src/components/Param.tsx
+++ b/client/src/components/Param.tsx
@@ -1,4 +1,4 @@
-import { Param as GenericParam } from "@mintlify/components";
+import { Param as GenericParam } from '@mintlify/components';
 
 export type ParamProps = {
   query?: string;
@@ -18,7 +18,7 @@ export type ParamProps = {
 
 // 9/8/2022 - Migrate everyone off Param
 export function Param(props: ParamProps) {
-  return <ParamField {...props} />
+  return <ParamField {...props} />;
 }
 
 // Also props: query, body, path
@@ -33,7 +33,7 @@ export function ParamField({
   hidden = false,
   last,
   placeholder,
-  enum: enumValues
+  enum: enumValues,
 }: ParamProps) {
   if (!query && !path && !body) {
     return null;
@@ -48,7 +48,8 @@ export function ParamField({
       type={type}
       required={required}
       hidden={hidden}
-      nameClasses="text-primary dark:text-primary-light">
+      nameClasses="text-primary dark:text-primary-light"
+    >
       {children}
     </GenericParam>
   );

--- a/client/src/enums/components.ts
+++ b/client/src/enums/components.ts
@@ -1,0 +1,8 @@
+export enum Component {
+  ParamField = 'ParamField',
+  Expandable = 'Expandable',
+  ResponseExample = 'ResponseExample',
+  RequestExample = 'RequestExample',
+  // Depreciated
+  Param = 'Param',
+}

--- a/client/src/layouts/ApiSupplemental.tsx
+++ b/client/src/layouts/ApiSupplemental.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect } from 'react';
 
 import { RequestExample, ResponseExample } from '@/components/ApiExample';
 import { Editor } from '@/components/Editor';
+import { Component } from '@/enums/components';
 import { CopyToClipboard } from '@/icons/CopyToClipboard';
 import { getOpenApiOperationMethodAndEndpoint } from '@/utils/getOpenApiContext';
 
@@ -35,11 +36,11 @@ export function ApiSupplemental({
   const [mdxResponseExample, setMdxResponseExample] = useState<JSX.Element | undefined>(undefined);
   useEffect(() => {
     const requestComponentSkeleton = apiComponents.find((apiComponent) => {
-      return apiComponent.type === 'RequestExample';
+      return apiComponent.type === Component.RequestExample;
     });
 
     const responseComponentSkeleton = apiComponents.find((apiComponent) => {
-      return apiComponent.type === 'ResponseExample';
+      return apiComponent.type === Component.ResponseExample;
     });
 
     const htmlToReactComponent = (html: string) => {

--- a/client/src/layouts/OpenApiContent.tsx
+++ b/client/src/layouts/OpenApiContent.tsx
@@ -5,6 +5,7 @@ import { Heading } from '@/components/Heading';
 import { ParamField } from '@/components/Param';
 import { ResponseField } from '@/components/ResponseField';
 import { config } from '@/config';
+import { Component } from '@/enums/components';
 import { openApi } from '@/openapi';
 import { Api, APIBASE_CONFIG_STORAGE, ApiComponent } from '@/ui/Api';
 import { MediaType } from '@/utils/api';
@@ -159,7 +160,7 @@ export function OpenApiContent({ openapi, auth }: OpenApiContentProps) {
     const paramName = { [paramType]: name };
     const type = getType(schema);
     apiComponents.push({
-      type: 'ParamField',
+      type: Component.ParamField,
       attributes: [
         {
           type: 'mdx',
@@ -216,7 +217,7 @@ export function OpenApiContent({ openapi, auth }: OpenApiContentProps) {
         : undefined;
       const last = i + 1 === operation.parameters?.length;
       apiComponents.push({
-        type: 'ParamField',
+        type: Component.ParamField,
         attributes: [
           {
             type: 'mdx',

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -3,6 +3,7 @@ import isAbsoluteUrl from 'is-absolute-url';
 
 import { ParamProps } from '@/components/Param';
 import { config } from '@/config';
+import { Component } from '@/enums/components';
 import { openApi } from '@/openapi';
 import { ApiComponent } from '@/ui/Api';
 
@@ -188,12 +189,16 @@ export const getParamGroupsFromAPIComponents = (
   }
 
   const paramFields = apiComponents
-    ?.filter((apiComponent) => apiComponent.type === 'ParamField')
+    ?.filter((apiComponent) => apiComponent.type === Component.ParamField)
     .map((apiComponent) => {
       const attributesMap: Record<any, any> = {};
       apiComponent?.attributes?.forEach((attribute: any) => {
         attributesMap[attribute.name] = attribute.value;
       });
+
+      // if (apiComponent.children && apiComponent.children[0]?.name === Component.Expandable) {
+      //   console.log('Hey there');
+      // }
 
       return attributesMap;
     });


### PR DESCRIPTION
# Summary

Add enums for components name. Currently only for client (nothing for `next.config.js`)
