### PR TITLE
Open all nested menus in Docusaurus before scraping

### DIFF
--- a/packages/mintlify/src/index.ts
+++ b/packages/mintlify/src/index.ts
@@ -15,8 +15,8 @@ import {
   scrapeSectionAutomatically,
   scrapeSectionAxiosWrapper,
   scrapeGitbookSectionCommand,
+  scrapeDocusaurusSectionCommand,
 } from "./scraping/scrapeSectionCommands.js";
-import { scrapeDocusaurusSection } from "./scraping/site-scrapers/scrapeDocusaurusSection.js";
 import { scrapeReadMeSection } from "./scraping/site-scrapers/scrapeReadMeSection.js";
 import dev from "./local-preview/index.js";
 
@@ -91,7 +91,7 @@ yargs(hideBin(process.argv))
     "Scrapes the Docusaurus section",
     () => {},
     async (argv) => {
-      await scrapeSectionAxiosWrapper(argv, scrapeDocusaurusSection);
+      await scrapeDocusaurusSectionCommand(argv);
     }
   )
   .command(

--- a/packages/mintlify/src/scraping/scrapeSectionCommands.ts
+++ b/packages/mintlify/src/scraping/scrapeSectionCommands.ts
@@ -3,21 +3,11 @@ import { detectFramework, Frameworks } from "./detectFramework.js";
 import { getHrefFromArgs, getOrigin } from "../util.js";
 import { scrapeSection } from "./scrapeSection.js";
 import { scrapeDocusaurusSection } from "./site-scrapers/scrapeDocusaurusSection.js";
+import openNestedDocusaurusMenus from "./site-scrapers/openNestedDocusaurusMenus.js";
 import { scrapeGitBookSection } from "./site-scrapers/scrapeGitBookSection.js";
+import openNestedGitbookMenus from "./site-scrapers/openNestedGitbookMenus.js";
 import { scrapeReadMeSection } from "./site-scrapers/scrapeReadMeSection.js";
 import { startBrowser } from "../browser.js";
-
-function validateFramework(framework: Frameworks | undefined) {
-  if (!framework) {
-    console.log(
-      "Could not detect the framework automatically. Please use one of:"
-    );
-    console.log("scrape-page-docusaurus");
-    console.log("scrape-page-gitbook");
-    console.log("scrape-page-readme");
-    return process.exit(1);
-  }
-}
 
 export async function scrapeSectionAxiosWrapper(argv: any, scrapeFunc: any) {
   const href = getHrefFromArgs(argv);
@@ -27,11 +17,27 @@ export async function scrapeSectionAxiosWrapper(argv: any, scrapeFunc: any) {
   process.exit(0);
 }
 
-export async function scrapeGitbookSectionCommand(argv: any) {
-  await scrapeSectionGitBookWrapper(argv, scrapeGitBookSection);
+export async function scrapeDocusaurusSectionCommand(argv: any) {
+  await scrapeSectionOpeningAllNested(
+    argv,
+    openNestedDocusaurusMenus,
+    scrapeDocusaurusSection
+  );
 }
 
-async function scrapeSectionGitBookWrapper(argv: any, scrapeFunc: any) {
+export async function scrapeGitbookSectionCommand(argv: any) {
+  await scrapeSectionOpeningAllNested(
+    argv,
+    openNestedGitbookMenus,
+    scrapeGitBookSection
+  );
+}
+
+async function scrapeSectionOpeningAllNested(
+  argv: any,
+  openLinks: any,
+  scrapeFunc: any
+) {
   const href = getHrefFromArgs(argv);
 
   const browser = await startBrowser();
@@ -40,51 +46,7 @@ async function scrapeSectionGitBookWrapper(argv: any, scrapeFunc: any) {
     waitUntil: "networkidle2",
   });
 
-  let prevEncountered: string[] = [];
-  let encounteredHref = ["fake"];
-
-  // Loop until we've encountered every link
-  while (!encounteredHref.every((href) => prevEncountered.includes(href))) {
-    prevEncountered = encounteredHref;
-    encounteredHref = await page.evaluate(
-      (encounteredHref) => {
-        const icons: HTMLElement[] = Array.from(
-          document.querySelectorAll('path[d="M9 18l6-6-6-6"]')
-        );
-
-        const linksFound: string[] = [];
-        icons.forEach(async (icon: HTMLElement) => {
-          const toClick = icon?.parentElement?.parentElement;
-          const link = toClick?.parentElement?.parentElement;
-
-          // Skip icons not in the side navigation
-          if (!link?.hasAttribute("href")) {
-            return;
-          }
-
-          const href = link.getAttribute("href");
-
-          // Should never occur but we keep it as a fail-safe
-          if (href?.startsWith("https://") || href?.startsWith("http://")) {
-            return;
-          }
-
-          // Click any links we haven't seen before
-          if (href && !encounteredHref.includes(href)) {
-            toClick?.click();
-          }
-          if (href) {
-            linksFound.push(href);
-          }
-        });
-
-        return linksFound;
-      },
-      encounteredHref // Need to pass array into the browser
-    );
-  }
-
-  const html = await page.content();
+  const html = await openLinks(page);
   browser.close();
   await scrapeSection(scrapeFunc, html, getOrigin(href), argv.overwrite);
   process.exit(0);
@@ -101,10 +63,22 @@ export async function scrapeSectionAutomatically(argv: any) {
   console.log("Detected framework: " + framework);
 
   if (framework === Frameworks.DOCUSAURUS) {
-    await scrapeSectionAxiosWrapper(argv, scrapeDocusaurusSection);
+    await scrapeDocusaurusSectionCommand(argv);
   } else if (framework === Frameworks.GITBOOK) {
     await scrapeGitbookSectionCommand(argv);
   } else if (framework === Frameworks.README) {
     await scrapeSectionAxiosWrapper(argv, scrapeReadMeSection);
+  }
+}
+
+function validateFramework(framework: Frameworks | undefined) {
+  if (!framework) {
+    console.log(
+      "Could not detect the framework automatically. Please use one of:"
+    );
+    console.log("scrape-page-docusaurus");
+    console.log("scrape-page-gitbook");
+    console.log("scrape-page-readme");
+    return process.exit(1);
   }
 }

--- a/packages/mintlify/src/scraping/site-scrapers/openNestedDocusaurusMenus.ts
+++ b/packages/mintlify/src/scraping/site-scrapers/openNestedDocusaurusMenus.ts
@@ -1,0 +1,43 @@
+import { Page } from "puppeteer";
+
+export default async function openNestedDocusaurusMenus(page: Page) {
+  let prevEncountered: string[] = [];
+  let encounteredHref = ["fake-href-to-make-loop-run-at-least-once"];
+
+  // Loop until we've encountered every link
+  while (!encounteredHref.every((href) => prevEncountered.includes(href))) {
+    prevEncountered = encounteredHref;
+    encounteredHref = await page.evaluate(
+      (encounteredHref) => {
+        const icons: HTMLElement[] = Array.from(
+          document.querySelectorAll(".clean-btn.menu__caret")
+        );
+
+        const linksFound: string[] = [];
+        icons.forEach(async (icon: HTMLElement) => {
+          const href =
+            icon?.parentElement?.firstElementChild?.getAttribute("href");
+
+          // Should never occur but we keep it as a fail-safe
+          if (href?.startsWith("https://") || href?.startsWith("http://")) {
+            return;
+          }
+
+          // Click any links we haven't seen before
+          if (href && !encounteredHref.includes(href)) {
+            icon?.click();
+          }
+
+          if (href) {
+            linksFound.push(href);
+          }
+        });
+
+        return linksFound;
+      },
+      encounteredHref // Need to pass array into the browser
+    );
+  }
+
+  return await page.content();
+}

--- a/packages/mintlify/src/scraping/site-scrapers/openNestedGitbookMenus.ts
+++ b/packages/mintlify/src/scraping/site-scrapers/openNestedGitbookMenus.ts
@@ -1,0 +1,49 @@
+import { Page } from "puppeteer";
+
+export default async function openNestedGitbookMenus(page: Page) {
+  let prevEncountered: string[] = [];
+  let encounteredHref = ["fake-href-to-make-loop-run-at-least-once"];
+
+  // Loop until we've encountered every link
+  while (!encounteredHref.every((href) => prevEncountered.includes(href))) {
+    prevEncountered = encounteredHref;
+    encounteredHref = await page.evaluate(
+      (encounteredHref) => {
+        const icons: HTMLElement[] = Array.from(
+          document.querySelectorAll('path[d="M9 18l6-6-6-6"]')
+        );
+
+        const linksFound: string[] = [];
+        icons.forEach(async (icon: HTMLElement) => {
+          const toClick = icon?.parentElement?.parentElement;
+          const link = toClick?.parentElement?.parentElement;
+
+          // Skip icons not in the side navigation
+          if (!link?.hasAttribute("href")) {
+            return;
+          }
+
+          const href = link.getAttribute("href");
+
+          // Should never occur but we keep it as a fail-safe
+          if (href?.startsWith("https://") || href?.startsWith("http://")) {
+            return;
+          }
+
+          // Click any links we haven't seen before
+          if (href && !encounteredHref.includes(href)) {
+            toClick?.click();
+          }
+          if (href) {
+            linksFound.push(href);
+          }
+        });
+
+        return linksFound;
+      },
+      encounteredHref // Need to pass array into the browser
+    );
+  }
+
+  return await page.content();
+}


### PR DESCRIPTION
Docusaurus doesn't fetch all pages until you open the menus. This PR uses puppeteer to open each nested menu before scraping so all pages are in the HTML.

The PR also refactors Gitbook's puppeteer logic to share code with Docusaurus.