### PR TITLE
Content type meta

### DIFF
--- a/client/src/layouts/ContentsLayout.tsx
+++ b/client/src/layouts/ContentsLayout.tsx
@@ -175,6 +175,7 @@ export type Meta = {
   auth?: string;
   api?: string;
   openapi?: string;
+  contentType?: string;
   size?: 'wide';
 };
 
@@ -220,6 +221,7 @@ export function ContentsLayout({
         description={meta.description}
         api={meta.api}
         openapi={meta.openapi}
+        contentType={meta.contentType}
         auth={meta.auth}
         section={section}
         children={children}

--- a/client/src/layouts/DocumentationLayout.tsx
+++ b/client/src/layouts/DocumentationLayout.tsx
@@ -27,11 +27,11 @@ export function DocumentationLayout({
     return <>{children}</>;
   }
 
+  const title = meta.sidebarTitle || meta.title;
+
   return (
     <>
-      <Title suffix={router.pathname === '/' ? '' : config.name}>
-        {meta.sidebarTitle || meta.title}
-      </Title>
+      <Title suffix={router.pathname === '/' ? '' : config.name}>{title}</Title>
       <SidebarLayout nav={documentationNav} navIsOpen={navIsOpen} setNavIsOpen={setNavIsOpen}>
         {children}
       </SidebarLayout>

--- a/client/src/layouts/OpenApiContent.tsx
+++ b/client/src/layouts/OpenApiContent.tsx
@@ -8,7 +8,6 @@ import { config } from '@/config';
 import { Component } from '@/enums/components';
 import { openApi } from '@/openapi';
 import { Api, APIBASE_CONFIG_STORAGE, ApiComponent } from '@/ui/Api';
-import { MediaType } from '@/utils/api';
 import { getOpenApiOperationMethodAndEndpoint } from '@/utils/getOpenApiContext';
 
 type OpenApiContentProps = {
@@ -21,15 +20,6 @@ const getType = (schema: any) => {
     return 'file';
   }
   return schema.type;
-};
-
-const getMedia = (name: string): MediaType => {
-  switch (name) {
-    case 'multipart/form-data':
-      return 'form';
-    default:
-      return 'json';
-  }
 };
 
 const getEnumDescription = (enumArray?: string[]): React.ReactNode | null => {
@@ -204,8 +194,8 @@ export function OpenApiContent({ openapi, auth }: OpenApiContentProps) {
   });
 
   const bodyContent = operation.requestBody?.content;
-  const contentMedia = bodyContent && Object.keys(bodyContent)[0];
-  const bodySchema = bodyContent && bodyContent[contentMedia]?.schema;
+  const contentType = bodyContent && Object.keys(bodyContent)[0];
+  const bodySchema = bodyContent && bodyContent[contentType]?.schema;
 
   const Body =
     bodySchema?.properties &&
@@ -275,7 +265,7 @@ export function OpenApiContent({ openapi, auth }: OpenApiContentProps) {
 
   return (
     <div className="prose prose-slate dark:prose-dark">
-      <Api api={api} media={getMedia(contentMedia)} auth={auth} apiComponents={apiComponents} />
+      <Api api={api} contentType={contentType} auth={auth} apiComponents={apiComponents} />
       <div>
         {Parameters?.length > 0 && (
           <Heading level={3} id="parameters" nextElement={null}>

--- a/client/src/metadata.ts
+++ b/client/src/metadata.ts
@@ -1,7 +1,7 @@
 import metadataJson from './metadata.json';
 
 export const documentationNav: Groups = metadataJson;
-export const nonMetaTags = ['api', 'openapi', 'sidebarTitle'];
+export const nonMetaTags = ['api', 'openapi', 'sidebarTitle', 'contentType'];
 
 export type PageContext = {
   title?: string;
@@ -9,6 +9,7 @@ export type PageContext = {
   description?: string;
   api?: string;
   openapi?: string;
+  contentType?: string;
   href?: string;
 };
 

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -87,6 +87,8 @@ export default function App(props: any) {
 
   let section = undefined;
   let meta: Meta = {};
+
+  const title = meta.sidebarTitle || meta.title;
   documentationNav.forEach((group) => {
     const foundPage = findPageInGroup(group, router.pathname);
     if (foundPage) {
@@ -101,10 +103,11 @@ export default function App(props: any) {
     if (nonMetaTags.includes(key)) return;
     metaTags[key as keyof PageContext] = value;
   });
+
   return (
     <Intercom appId={config.integrations?.intercom} autoBoot>
       <AnalyticsContext.Provider value={analyticsMediator}>
-        <Title suffix={config.name}>{meta.sidebarTitle || meta.title}</Title>
+        <Title suffix={config.name}>{title}</Title>
         <Head>
           {config?.metadata &&
             Object.entries(config?.metadata).map(([key, value]) => {

--- a/client/src/ui/Api.tsx
+++ b/client/src/ui/Api.tsx
@@ -8,7 +8,6 @@ import {
   extractMethodAndEndpoint,
   getApiContext,
   getParamGroupsFromAPIComponents,
-  MediaType,
   Param,
   ParamGroup,
 } from '@/utils/api';
@@ -33,13 +32,13 @@ export const APIBASE_CONFIG_STORAGE = 'apiBaseIndex';
 
 export function Api({
   api,
-  media = 'json',
+  contentType = 'application/json',
   auth,
   children,
   apiComponents,
 }: {
   api: string;
-  media?: MediaType;
+  contentType?: string;
   auth?: string;
   children?: any;
   apiComponents?: ApiComponent[];
@@ -101,7 +100,7 @@ export function Api({
     setIsSendingResponse(true);
 
     try {
-      const apiContext = getApiContext(apiBase, path, inputData, media);
+      const apiContext = getApiContext(apiBase, path, inputData, contentType);
       const { data } = await axios.post('/api/request', {
         method,
         ...apiContext,
@@ -165,6 +164,7 @@ export function Api({
           />
         );
       case 'file':
+      case 'files':
         return (
           <button className="relative flex items-center px-2 w-full h-7 rounded border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-700 dark:text-slate-200 border-dashed hover:bg-slate-50 dark:hover:bg-slate-800">
             <input

--- a/client/src/ui/PageHeader.tsx
+++ b/client/src/ui/PageHeader.tsx
@@ -6,6 +6,7 @@ type PageHeaderProps = {
   description?: string;
   api?: string;
   openapi?: string;
+  contentType?: string;
   auth?: string;
   section: string;
   children: any;
@@ -17,6 +18,7 @@ export function PageHeader({
   description,
   section,
   api,
+  contentType, // TODO: Add documentation
   auth,
   children,
   apiComponents,
@@ -45,7 +47,15 @@ export function PageHeader({
       {description && (
         <p className="mt-2 text-lg text-slate-700 dark:text-slate-400">{description}</p>
       )}
-      {api && <Api api={api} children={children} auth={auth} apiComponents={apiComponents} />}
+      {api && (
+        <Api
+          api={api}
+          children={children}
+          auth={auth}
+          apiComponents={apiComponents}
+          contentType={contentType}
+        />
+      )}
     </header>
   );
 }

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -59,7 +59,7 @@ const potentiallAddPathParams = (inputUrl: string, inputData: Record<string, any
   return url;
 };
 
-const getApiBody = (obj: Object, contentType: string) => {
+const getBody = (obj: Object, contentType: string) => {
   if (contentType === 'multipart/form-data') {
     let cleanedObj = removeEmpty(obj);
     const bodyFormData = new FormData();
@@ -72,6 +72,13 @@ const getApiBody = (obj: Object, contentType: string) => {
   return removeEmpty(obj);
 };
 
+const getHeaders = (obj: AxiosRequestHeaders, contentType: string): AxiosRequestHeaders => {
+  return {
+    ...obj,
+    'Content-Type': contentType,
+  };
+};
+
 export const getApiContext = (
   apiBase: string,
   path: string,
@@ -80,9 +87,11 @@ export const getApiContext = (
 ): { url: string; body?: Object; params?: Object; headers?: AxiosRequestHeaders } => {
   const endpoint = `${apiBase}${path}`;
   const url = potentiallAddPathParams(endpoint, inputData);
-  const body = getApiBody(inputData.Body, contentType);
+  const body = getBody(inputData.Body, contentType);
   const params = removeEmpty(inputData.Query);
-  const headers: AxiosRequestHeaders = inputData.Header || {};
+  const headers = getHeaders(inputData.Header || {}, contentType);
+
+  console.log(headers);
 
   if (inputData.Authorization) {
     const authEntires = Object.entries(inputData.Authorization);

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -7,8 +7,6 @@ import { Component } from '@/enums/components';
 import { openApi } from '@/openapi';
 import { ApiComponent } from '@/ui/Api';
 
-export type MediaType = 'json' | 'form';
-
 export type Child = {
   props: ParamProps & { mdxType: string };
 };
@@ -61,8 +59,8 @@ const potentiallAddPathParams = (inputUrl: string, inputData: Record<string, any
   return url;
 };
 
-const getApiBody = (obj: Object, media: MediaType) => {
-  if (media === 'form') {
+const getApiBody = (obj: Object, contentType: string) => {
+  if (contentType === 'multipart/form-data') {
     let cleanedObj = removeEmpty(obj);
     const bodyFormData = new FormData();
     for (var key in cleanedObj) {
@@ -78,11 +76,11 @@ export const getApiContext = (
   apiBase: string,
   path: string,
   inputData: Record<string, any>,
-  media: MediaType
+  contentType: string
 ): { url: string; body?: Object; params?: Object; headers?: AxiosRequestHeaders } => {
   const endpoint = `${apiBase}${path}`;
   const url = potentiallAddPathParams(endpoint, inputData);
-  const body = getApiBody(inputData.Body, media);
+  const body = getApiBody(inputData.Body, contentType);
   const params = removeEmpty(inputData.Query);
   const headers: AxiosRequestHeaders = inputData.Header || {};
 

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -91,8 +91,6 @@ export const getApiContext = (
   const params = removeEmpty(inputData.Query);
   const headers = getHeaders(inputData.Header || {}, contentType);
 
-  console.log(headers);
-
   if (inputData.Authorization) {
     const authEntires = Object.entries(inputData.Authorization);
     if (config.api?.auth?.method === 'basic' && authEntires.length === 2) {


### PR DESCRIPTION
# Summary

This PR adds the `contentType` meta data that adjusts the `Content-Type` of API requests. By default, all requests are `application/json`.