### PR TITLE
Concurrency

### DIFF
--- a/client/next.config.js
+++ b/client/next.config.js
@@ -22,7 +22,8 @@ export default withSentryConfig(
     images: {
       disableStaticImages: true,
     },
-    webpack(config, options) {
+    staticPageGenerationTimeout: 1000,
+    webpack(config) {
       config.module.rules.push({
         test: /\.(png|jpe?g|gif|webp|avif|mp4)$/i,
         issuer: /\.(jsx?|tsx?|mdx?)$/,

--- a/client/src/lib/paths.ts
+++ b/client/src/lib/paths.ts
@@ -1,11 +1,18 @@
 import axios from 'axios';
 
+const REQUEST_ADMIN_OPTIONS = {
+  headers: { Authorization: `Bearer ${process.env.ADMIN_TOKEN}` },
+};
+
 const sleep = (ms: number) => {
   return new Promise((resolve) => setTimeout(resolve, ms));
 };
 
 const checkWorkerStatus = async (id: string): Promise<any> => {
-  const status = await axios.get(`${process.env.API_ENDPOINT}/api/v1/admin/build/cache-all/${id}`);
+  const status = await axios.get(
+    `${process.env.API_ENDPOINT}/api/v1/admin/build/cache-all/${id}`,
+    REQUEST_ADMIN_OPTIONS
+  );
   return status.data;
 };
 
@@ -35,18 +42,23 @@ export const monitorWorkerStatus = async (id: string) => {
 const cacheAll = async () => {
   const {
     data: { id },
-  } = await axios.post(`${process.env.API_ENDPOINT}/api/v1/admin/build/cache-all`);
+  } = await axios.post(
+    `${process.env.API_ENDPOINT}/api/v1/admin/build/cache-all`,
+    null,
+    REQUEST_ADMIN_OPTIONS
+  );
   return id;
 };
 
 export const getPaths = async () => {
-  const id = await cacheAll();
-  await monitorWorkerStatus(id);
+  // Only cache all in production ~ called only once in build
+  if (process.env.NODE_ENV === 'production') {
+    const id = await cacheAll();
+    await monitorWorkerStatus(id);
+  }
   const { data }: { data: Record<string, string[][]> } = await axios.get(
     `${process.env.API_ENDPOINT}/api/v1/admin/build/paths`,
-    {
-      headers: { Authorization: `Bearer ${process.env.ADMIN_TOKEN}` },
-    }
+    REQUEST_ADMIN_OPTIONS
   );
   return data;
 };

--- a/client/src/lib/paths.ts
+++ b/client/src/lib/paths.ts
@@ -1,6 +1,47 @@
 import axios from 'axios';
 
+const sleep = (ms: number) => {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+};
+
+const checkWorkerStatus = async (id: string): Promise<any> => {
+  const status = await axios.get(`${process.env.API_ENDPOINT}/api/v1/admin/build/cache-all/${id}`);
+  return status.data;
+};
+
+const THREE_MINUTES_IN_MS = 1000 * 60 * 3;
+
+export const monitorWorkerStatus = async (id: string) => {
+  let workerStatus = null;
+  let millisecondsPassed = 0;
+  const intervalMs = 100;
+
+  while (workerStatus == null && millisecondsPassed < THREE_MINUTES_IN_MS) {
+    const status = await checkWorkerStatus(id);
+    if (status.state === 'completed' && status.data) {
+      workerStatus = status.data;
+      break;
+    } else if (status.state === 'failed') {
+      throw new Error('Unable to generate documentation');
+    }
+
+    millisecondsPassed += intervalMs;
+    await sleep(intervalMs);
+  }
+
+  return workerStatus;
+};
+
+const cacheAll = async () => {
+  const {
+    data: { id },
+  } = await axios.post(`${process.env.API_ENDPOINT}/api/v1/admin/build/cache-all`);
+  return id;
+};
+
 export const getPaths = async () => {
+  const id = await cacheAll();
+  await monitorWorkerStatus(id);
   const { data }: { data: Record<string, string[][]> } = await axios.get(
     `${process.env.API_ENDPOINT}/api/v1/admin/build/paths`,
     {


### PR DESCRIPTION
# Summary

This PR enables it so that `cacheAll` is ran on everytime `getPaths` is run. It's **really** important that `getPaths` only is run once during build and that it's only really called for the production instance.

# Test Plan

- Uncomment out the `process.env.NODE_ENV === 'production'` in path.ts. And refresh the page once.
- Check the output logs on the server to see that requests are being routinely made to check the status of the cache
- Once that cache completes, you should be able to run `redis-server` and `get [NAME OF ORG]` to see the cache of any deployment