### PR TITLE
Enable Incremental Static Regeneration

### DIFF
--- a/client/src/lib/paths.ts
+++ b/client/src/lib/paths.ts
@@ -42,8 +42,9 @@ export const monitorGetPathsStatus = async (id: string) => {
 export const getPaths = async () => {
   const {
     data: { id },
-  }: { data: { id: string } } = await axios.get(
+  }: { data: { id: string } } = await axios.post(
     `${process.env.API_ENDPOINT}/api/v1/admin/build/paths`,
+    null,
     REQUEST_ADMIN_OPTIONS
   );
   const paths = await monitorGetPathsStatus(id);

--- a/client/src/lib/paths.ts
+++ b/client/src/lib/paths.ts
@@ -10,7 +10,7 @@ const sleep = (ms: number) => {
 
 const checkGetPathsStatus = async (id: string): Promise<any> => {
   const status = await axios.get(
-    `${process.env.API_ENDPOINT}/api/v1/admin/build/get-paths/${id}`,
+    `${process.env.API_ENDPOINT}/api/v1/admin/build/paths/${id}`,
     REQUEST_ADMIN_OPTIONS
   );
   return status.data;

--- a/client/src/pages/_sites/[site]/[[...slug]].tsx
+++ b/client/src/pages/_sites/[site]/[[...slug]].tsx
@@ -210,7 +210,7 @@ export const getStaticPaths: GetStaticPaths<PathProps> = async () => {
   );
   return {
     paths,
-    fallback: true, // TODO: Change this to true once ISR is implemented https://nextjs.org/docs/api-reference/data-fetching/get-static-paths#fallback-true
+    fallback: true,
   };
 };
 

--- a/client/src/pages/api/revalidate.ts
+++ b/client/src/pages/api/revalidate.ts
@@ -1,0 +1,19 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { secret, path } = req.body;
+  if (secret !== process.env.ADMIN_TOKEN) {
+    return res.status(401).json({ error: 'Invalid token' });
+  }
+
+  if (!path) {
+    return res.status(400).json({ error: 'No path provided' });
+  }
+
+  try {
+    await res.revalidate(path);
+    return res.json({ revalidated: true });
+  } catch (err) {
+    return res.status(500).send('Error revalidating');
+  }
+}


### PR DESCRIPTION
# Summary

This PR introduces the `api/revalidate` endpoint, which is used for [On-demand Revalidation](https://nextjs.org/docs/basic-features/data-fetching/incremental-static-regeneration#on-demand-revalidation)