### PR TITLE
Navigate home on version change

### DIFF
--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -29,7 +29,7 @@ type NavbarLink = {
 
 export type TopbarCta = NavbarLink;
 
-type Anchor = {
+export type Anchor = {
   name: string;
   url: string;
   icon?: string;

--- a/client/src/layouts/DocumentationLayout.tsx
+++ b/client/src/layouts/DocumentationLayout.tsx
@@ -1,11 +1,12 @@
 import { useRouter } from 'next/router';
-import { ReactNode, useContext } from 'react';
+import { ReactNode, useContext, useEffect } from 'react';
 
 import { config } from '@/config';
 import { VersionContext } from '@/context/VersionContext';
 import { SidebarLayout } from '@/layouts/SidebarLayout';
 import { documentationNav } from '@/metadata';
 import { Title } from '@/ui/Title';
+import { getCurrentAnchorVersion } from '@/utils/getCurrentAnchor';
 
 import { Meta } from './ContentsLayout';
 

--- a/client/src/ui/VersionSelect.tsx
+++ b/client/src/ui/VersionSelect.tsx
@@ -13,11 +13,12 @@ export function VersionSelect() {
   // Only run when the page loads. Otherwise, users could never change the API version
   // because the page would keep changing it back to its own version.
   useEffect(() => {
-    const version = getVersionOfPage(router.pathname.substring(1));
+    const version = getVersionOfPage(router.pathname);
     if (version) {
       setSelectedVersion(version);
     }
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [setSelectedVersion]);
 
   // It's possible to show a selected version that doesn't exist in versionOptions, for example by navigating to
   // a secret v3 page when the menu only shows v1 and v2. Thus, we only hide the dropdown when nothing is selected.
@@ -27,6 +28,7 @@ export function VersionSelect() {
 
   const onClickVersion = (version: string) => {
     setSelectedVersion(version);
+    router.push('/');
   };
 
   return (

--- a/client/src/utils/getCurrentAnchor.ts
+++ b/client/src/utils/getCurrentAnchor.ts
@@ -1,0 +1,11 @@
+import { Anchor } from '@/config';
+
+export function getCurrentAnchor(anchors: Anchor[], pathname: string) {
+  return anchors.find((anchor) => {
+    return pathname.startsWith(`/${anchor.url}`);
+  });
+}
+
+export function getCurrentAnchorVersion(anchors: Anchor[], pathname: string) {
+  return getCurrentAnchor(anchors, pathname)?.version;
+}

--- a/client/src/utils/nav.ts
+++ b/client/src/utils/nav.ts
@@ -1,6 +1,8 @@
 import { config } from '@/config';
 import { Group, Groups, GroupPage, isGroup } from '@/metadata';
 
+import { getCurrentAnchorVersion } from './getCurrentAnchor';
+
 export function getGroupsInDivision(nav: Groups, divisionUrls: string[]) {
   return nav.filter((group: Group) => isGroupInDivision(group, divisionUrls));
 }
@@ -97,6 +99,10 @@ function getVersionOfPageRecursively(
   }
 }
 
-export function getVersionOfPage(targetPage: string): string | void {
-  return getVersionOfPageRecursively(config.navigation, targetPage);
+export function getVersionOfPage(pathname: string): string | void {
+  const pageVersion = getVersionOfPageRecursively(config.navigation, pathname.substring(1));
+  if (pageVersion) {
+    return pageVersion;
+  }
+  return getCurrentAnchorVersion(config.anchors || [], pathname);
 }


### PR DESCRIPTION
Changes the current version to the anchor's version when you are directly linked to a page in a versioned anchor.

Also navigates to the home page whenever you manually switch versions.