### PR TITLE
Enable Multiple OpenAPI specs for versioning

### DIFF
--- a/client/prebuild/getOpenApiContext.js
+++ b/client/prebuild/getOpenApiContext.js
@@ -20,7 +20,7 @@ export const getOpenApiOperationMethodAndEndpoint = (openApi, openApiMetaField) 
 
   let path;
 
-  openApi.files.forEach((file) => {
+  openApi.files?.forEach((file) => {
     const openApiFile = file.openapi;
     const openApiPath = openApiFile.paths && openApiFile.paths[endpoint];
     const isFilenameOrNone = !filename || filename === file.name;

--- a/client/prebuild/getOpenApiContext.js
+++ b/client/prebuild/getOpenApiContext.js
@@ -3,18 +3,31 @@ export const extractMethodAndEndpoint = (api) => {
   const trimmed = api.trim();
   const foundMethod = trimmed.match(methodRegex);
 
-  const endIndexOfMethod = foundMethod ? api.indexOf(foundMethod[0]) + foundMethod[0].length : 0;
+  const startIndexOfMethod = foundMethod ? api.indexOf(foundMethod[0]) : 0;
+  const endIndexOfMethod = foundMethod ? startIndexOfMethod + foundMethod[0].length : 0;
+
+  const filename = api.substring(0, startIndexOfMethod).trim();
 
   return {
     method: foundMethod ? foundMethod[0].toUpperCase() : undefined,
     endpoint: api.substring(endIndexOfMethod).trim(),
+    filename: filename ? filename : undefined,
   };
 };
 
-export const getOpenApiOperationMethodAndEndpoint = (openApiObj, openApiMetaField) => {
-  const { endpoint, method } = extractMethodAndEndpoint(openApiMetaField);
+export const getOpenApiOperationMethodAndEndpoint = (openApi, openApiMetaField) => {
+  const { endpoint, method, filename } = extractMethodAndEndpoint(openApiMetaField);
 
-  const path = openApiObj?.paths && openApiObj.paths[endpoint];
+  let path;
+
+  openApi.files.forEach((file) => {
+    const openApiFile = file.openapi;
+    const openApiPath = openApiFile.paths && openApiFile.paths[endpoint];
+    const isFilenameOrNone = !filename || filename === file.name;
+    if (openApiPath && isFilenameOrNone) {
+      path = openApiPath;
+    }
+  });
 
   if (path == null) {
     return {};
@@ -35,12 +48,12 @@ export const getOpenApiOperationMethodAndEndpoint = (openApiObj, openApiMetaFiel
   };
 };
 
-export const getOpenApiTitleAndDescription = (openApiObj, openApiMetaField) => {
-  if (openApiObj == null || !openApiMetaField || openApiMetaField == null) {
+export const getOpenApiTitleAndDescription = (openApi, openApiMetaField) => {
+  if (openApi == null || !openApiMetaField || openApiMetaField == null) {
     return {};
   }
 
-  const { operation } = getOpenApiOperationMethodAndEndpoint(openApiObj, openApiMetaField);
+  const { operation } = getOpenApiOperationMethodAndEndpoint(openApi, openApiMetaField);
 
   if (operation == null) {
     return {};

--- a/client/prebuild/getOpenApiContext.js
+++ b/client/prebuild/getOpenApiContext.js
@@ -1,15 +1,15 @@
 export const extractMethodAndEndpoint = (api) => {
-  const methodRegex = /^get|post|put|delete|patch/i;
+  const methodRegex = /(get|post|put|delete|patch)\s/i;
   const trimmed = api.trim();
   const foundMethod = trimmed.match(methodRegex);
 
   const startIndexOfMethod = foundMethod ? api.indexOf(foundMethod[0]) : 0;
-  const endIndexOfMethod = foundMethod ? startIndexOfMethod + foundMethod[0].length : 0;
+  const endIndexOfMethod = foundMethod ? startIndexOfMethod + foundMethod[0].length - 1 : 0;
 
   const filename = api.substring(0, startIndexOfMethod).trim();
 
   return {
-    method: foundMethod ? foundMethod[0].toUpperCase() : undefined,
+    method: foundMethod ? foundMethod[0].slice(0, -1).toUpperCase() : undefined,
     endpoint: api.substring(endIndexOfMethod).trim(),
     filename: filename ? filename : undefined,
   };

--- a/client/prebuild/index.js
+++ b/client/prebuild/index.js
@@ -13,11 +13,11 @@ const API_ENDPOINT = 'https://docs.mintlify.com';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-const injectMarkdownFilesAndNav = (markdownFiles, openApiObj, configObj) => {
+const injectMarkdownFilesAndNav = (markdownFiles, openApi, config) => {
   let pages = {};
   markdownFiles.forEach((markdownFile) => {
     const path = __dirname + `/../src/pages/${markdownFile.path}`;
-    const page = createPage(markdownFile.path, markdownFile.content, openApiObj);
+    const page = createPage(markdownFile.path, markdownFile.content, openApi);
     if (page != null) {
       pages = {
         ...pages,
@@ -30,7 +30,7 @@ const injectMarkdownFilesAndNav = (markdownFiles, openApiObj, configObj) => {
 
   console.log(`📄  ${markdownFiles.length} pages injected`);
 
-  injectNav(pages, configObj);
+  injectNav(pages, config);
 };
 
 const injectStaticFiles = (staticFiles) => {
@@ -75,10 +75,9 @@ const injectFavicons = async (config) => {
 const injectOpenApi = async (openApi) => {
   const path = __dirname + `/../src/openapi.json`;
   if (openApi) {
-    const buffer = Buffer.from(openApi);
-    fs.outputFileSync(path, buffer, { flag: 'w' });
+    fs.outputFileSync(path, JSON.stringify(openApi), { flag: 'w' });
     console.log('🖥️  OpenAPI file detected and set as openapi.json');
-    return JSON.parse(buffer.toString());
+    return;
   }
 
   fs.outputFileSync(path, '{}', { flag: 'w' });
@@ -94,9 +93,9 @@ const getAllFilesAndConfig = async () => {
       ref,
     },
   });
-  const openApiObj = await injectOpenApi(openApi);
+  injectOpenApi(openApi);
   injectConfig(config);
-  injectMarkdownFilesAndNav(markdownFiles, openApiObj, config);
+  injectMarkdownFilesAndNav(markdownFiles, openApi, config);
   injectStaticFiles(staticFiles);
   injectFavicons(config);
 };

--- a/client/prebuild/injectNav.js
+++ b/client/prebuild/injectNav.js
@@ -9,14 +9,14 @@ import { slugToTitle } from './slugToTitle.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-export const createPage = (path, content, openApiObj) => {
+export const createPage = (path, content, openApi) => {
   const slug = path.replace(/\.mdx?$/, '');
   let defaultTitle = slugToTitle(slug);
   const fileContents = Buffer.from(content).toString();
   const { data } = matter(fileContents);
   const metadata = data;
   // Append data from OpenAPI if it exists
-  const { title, description } = getOpenApiTitleAndDescription(openApiObj, metadata?.openapi);
+  const { title, description } = getOpenApiTitleAndDescription(openApi, metadata?.openapi);
   if (title) {
     defaultTitle = title;
   }

--- a/client/src/layouts/OpenApiContent.tsx
+++ b/client/src/layouts/OpenApiContent.tsx
@@ -288,8 +288,11 @@ export function OpenApiContent({ openapi, auth }: OpenApiContentProps) {
 
   let responseSchema = operation.responses?.['200']?.content?.['application/json']?.schema;
   // endpoint in OpenAPI refers to the path
+  const openApiServers = openApi?.files.reduce((acc, file) => {
+    return acc.concat(file.openapi.servers);
+  }, []);
   const configBaseUrl =
-    config.api?.baseUrl ?? openApi?.servers?.map((server: { url: string }) => server.url);
+    config.api?.baseUrl ?? openApiServers?.map((server: { url: string }) => server.url);
   const baseUrl =
     configBaseUrl && Array.isArray(configBaseUrl) ? configBaseUrl[apiBaseIndex] : configBaseUrl;
   const api = `${method} ${baseUrl}${endpoint}`;

--- a/client/src/layouts/OpenApiContent.tsx
+++ b/client/src/layouts/OpenApiContent.tsx
@@ -288,7 +288,7 @@ export function OpenApiContent({ openapi, auth }: OpenApiContentProps) {
 
   let responseSchema = operation.responses?.['200']?.content?.['application/json']?.schema;
   // endpoint in OpenAPI refers to the path
-  const openApiServers = openApi?.files.reduce((acc, file) => {
+  const openApiServers = openApi?.files?.reduce((acc, file) => {
     return acc.concat(file.openapi.servers);
   }, []);
   const configBaseUrl =

--- a/client/src/openapi.ts
+++ b/client/src/openapi.ts
@@ -1,3 +1,10 @@
 import openapiJSON from './openapi.json';
 
-export const openApi = openapiJSON as any;
+type OpenAPIFiles = {
+  files: {
+    name: string;
+    openapi: any;
+  }[];
+};
+
+export const openApi: OpenAPIFiles = openapiJSON;

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -127,16 +127,16 @@ export const getApiContext = (
 export const extractMethodAndEndpoint = (
   api: string
 ): { method?: string; endpoint: string; filename?: string } => {
-  const methodRegex = /^get|post|put|delete|patch/i;
+  const methodRegex = /(get|post|put|delete|patch)\s/i;
   const foundMethod = api.trim().match(methodRegex);
 
   const startIndexOfMethod = foundMethod ? api.indexOf(foundMethod[0]) : 0;
-  const endIndexOfMethod = foundMethod ? startIndexOfMethod + foundMethod[0].length : 0;
+  const endIndexOfMethod = foundMethod ? startIndexOfMethod + foundMethod[0].length - 1 : 0;
 
   const filename = api.substring(0, startIndexOfMethod).trim();
 
   return {
-    method: foundMethod ? foundMethod[0].toUpperCase() : undefined,
+    method: foundMethod ? foundMethod[0].slice(0, -1).toUpperCase() : undefined,
     endpoint: api.substring(endIndexOfMethod).trim(),
     filename: filename ? filename : undefined,
   };

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -124,22 +124,31 @@ export const getApiContext = (
   return { url, body, params, headers };
 };
 
-export const extractMethodAndEndpoint = (api: string) => {
+export const extractMethodAndEndpoint = (
+  api: string
+): { method?: string; endpoint: string; filename?: string } => {
   const methodRegex = /^get|post|put|delete|patch/i;
   const foundMethod = api.trim().match(methodRegex);
 
-  const endIndexOfMethod = foundMethod ? api.indexOf(foundMethod[0]) + foundMethod[0].length : 0;
+  const startIndexOfMethod = foundMethod ? api.indexOf(foundMethod[0]) : 0;
+  const endIndexOfMethod = foundMethod ? startIndexOfMethod + foundMethod[0].length : 0;
+
+  const filename = api.substring(0, startIndexOfMethod).trim();
 
   return {
     method: foundMethod ? foundMethod[0].toUpperCase() : undefined,
     endpoint: api.substring(endIndexOfMethod).trim(),
+    filename: filename ? filename : undefined,
   };
 };
 
 export const extractBaseAndPath = (endpoint: string, apiBaseIndex = 0) => {
   let fullEndpoint;
+  const openApiServers = openApi?.files.reduce((acc, file) => {
+    return acc.concat(file.openapi.servers);
+  }, []);
   const baseUrl =
-    config.api?.baseUrl ?? openApi?.servers?.map((server: { url: string }) => server.url);
+    config.api?.baseUrl ?? openApiServers?.map((server: { url: string }) => server.url);
   if (isAbsoluteUrl(endpoint)) {
     fullEndpoint = endpoint;
   } else if (baseUrl) {

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -132,7 +132,6 @@ export const extractMethodAndEndpoint = (
 
   const startIndexOfMethod = foundMethod ? api.indexOf(foundMethod[0]) : 0;
   const endIndexOfMethod = foundMethod ? startIndexOfMethod + foundMethod[0].length - 1 : 0;
-
   const filename = api.substring(0, startIndexOfMethod).trim();
 
   return {

--- a/client/src/utils/getOpenApiContext.ts
+++ b/client/src/utils/getOpenApiContext.ts
@@ -3,9 +3,18 @@ import { openApi } from '@/openapi';
 import { extractMethodAndEndpoint } from './api';
 
 export const getOpenApiOperationMethodAndEndpoint = (openapi: string) => {
-  const { endpoint, method } = extractMethodAndEndpoint(openapi);
+  const { endpoint, method, filename } = extractMethodAndEndpoint(openapi);
 
-  const path = openApi?.paths && openApi.paths[endpoint];
+  let path;
+
+  openApi.files.forEach((file) => {
+    const openApiFile = file.openapi;
+    const openApiPath = openApiFile.paths && openApiFile.paths[endpoint];
+    const isFilenameOrNone = !filename || filename === file.name;
+    if (openApiPath && isFilenameOrNone) {
+      path = openApiPath;
+    }
+  });
 
   if (path == null) {
     return {};

--- a/client/src/utils/getOpenApiContext.ts
+++ b/client/src/utils/getOpenApiContext.ts
@@ -7,7 +7,7 @@ export const getOpenApiOperationMethodAndEndpoint = (openapi: string) => {
 
   let path;
 
-  openApi.files.forEach((file) => {
+  openApi.files?.forEach((file) => {
     const openApiFile = file.openapi;
     const openApiPath = openApiFile.paths && openApiFile.paths[endpoint];
     const isFilenameOrNone = !filename || filename === file.name;


### PR DESCRIPTION
# Summary

- Enables support for new type of openapi.json, which allows for multiple files
- Supports accompanying functions to support multiple openapi specs but also the original setup

# Test Plan

- Check that normal docs without openapi specs are good (builds)
- Check companies with openapi specs
- Check Dots's setup with multiple openapi specs