### PR TITLE
Auto generate RequestExamples without parameters

### DIFF
--- a/client/rehype/withApiComponents.js
+++ b/client/rehype/withApiComponents.js
@@ -22,7 +22,7 @@ const withApiComponents = () => {
     let apiComponents = [];
     visit(tree, 'mdxJsxFlowElement', (node, _, parent) => {
       if (['ResponseExample', 'RequestExample'].includes(node.name)) {
-        // remove all jsx components to convert to html (removes <ResponseExample> and <Editor>)
+        // remove all jsx components to convert to html (removes <ResponseExample> and <RequestExample>)
         const children = node.children.map((child, i) => {
           const preComponent = child.children[0];
           const html = toHtml(preComponent);

--- a/client/src/enums/components.ts
+++ b/client/src/enums/components.ts
@@ -3,6 +3,6 @@ export enum Component {
   Expandable = 'Expandable',
   ResponseExample = 'ResponseExample',
   RequestExample = 'RequestExample',
-  // Depreciated
+  // Deprecated
   Param = 'Param',
 }

--- a/client/src/layouts/ApiSupplemental.tsx
+++ b/client/src/layouts/ApiSupplemental.tsx
@@ -32,11 +32,13 @@ export function ApiSupplemental({
   api,
   openapi,
   auth,
+  authName,
 }: {
   apiComponents: ApiComponent[];
   api?: string;
   openapi?: string;
   auth?: string;
+  authName?: string;
 }) {
   const [apiBaseIndex, setApiBaseIndex] = useState(0);
 
@@ -52,11 +54,7 @@ export function ApiSupplemental({
       ? getOpenApiOperationMethodAndEndpoint(openapi)
       : { operation: undefined, path: undefined };
   //const parameters = getAllOpenApiParameters(path, operation);
-  const paramGroups = getParamGroupsFromApiComponents(apiComponents, auth); // will include auth even if not set on each page
-  // remember param types not included will be undefined instead of an empty array
-  // console.log(api);
-  // console.log(openapi);
-  // console.log(paramGroups);
+  const paramGroups = getParamGroupsFromApiComponents(apiComponents, auth);
 
   // Response and Request Examples from MDX
   const [mdxRequestExample, setMdxRequestExample] = useState<JSX.Element | undefined>(undefined);
@@ -174,7 +172,7 @@ export function ApiSupplemental({
     <div className="space-y-6 pb-6">
       {mdxRequestExample
         ? mdxRequestExample
-        : generateRequestExamples(api, apiBaseIndex, paramGroups)}
+        : generateRequestExamples(api || openapi, apiBaseIndex, paramGroups, auth, authName)}
       {/* TODO - Make it so that you can see both the openapi and response example in 1 view if they're both defined */}
       {highlightedExamples.length === 0 && mdxResponseExample}
       {highlightedExamples.length > 0 && (

--- a/client/src/layouts/ApiSupplemental.tsx
+++ b/client/src/layouts/ApiSupplemental.tsx
@@ -1,5 +1,4 @@
 import axios from 'axios';
-import parse from 'html-react-parser';
 import React from 'react';
 import { useState, useEffect } from 'react';
 
@@ -7,7 +6,11 @@ import { RequestExample, ResponseExample } from '@/components/ApiExample';
 import { Editor } from '@/components/Editor';
 import { Component } from '@/enums/components';
 import { CopyToClipboard } from '@/icons/CopyToClipboard';
+import { APIBASE_CONFIG_STORAGE } from '@/ui/Api';
+import { getParamGroupsFromApiComponents } from '@/utils/api';
+import { generateRequestExamples } from '@/utils/generateAPIExamples';
 import { getOpenApiOperationMethodAndEndpoint } from '@/utils/getOpenApiContext';
+import { htmlToReactComponent } from '@/utils/htmlToReactComponent';
 
 const responseHasExample = (response: any) => {
   return (
@@ -26,11 +29,35 @@ type ApiComponent = {
 
 export function ApiSupplemental({
   apiComponents,
+  api,
   openapi,
+  auth,
 }: {
   apiComponents: ApiComponent[];
+  api?: string;
   openapi?: string;
+  auth?: string;
 }) {
+  const [apiBaseIndex, setApiBaseIndex] = useState(0);
+
+  useEffect(() => {
+    const configuredApiBaseIndex = window.localStorage.getItem(APIBASE_CONFIG_STORAGE);
+    if (configuredApiBaseIndex != null) {
+      setApiBaseIndex(parseInt(configuredApiBaseIndex, 10));
+    }
+  }, []);
+
+  const { operation, path } =
+    openapi != null
+      ? getOpenApiOperationMethodAndEndpoint(openapi)
+      : { operation: undefined, path: undefined };
+  //const parameters = getAllOpenApiParameters(path, operation);
+  const paramGroups = getParamGroupsFromApiComponents(apiComponents, auth); // will include auth even if not set on each page
+  // remember param types not included will be undefined instead of an empty array
+  // console.log(api);
+  // console.log(openapi);
+  // console.log(paramGroups);
+
   // Response and Request Examples from MDX
   const [mdxRequestExample, setMdxRequestExample] = useState<JSX.Element | undefined>(undefined);
   const [mdxResponseExample, setMdxResponseExample] = useState<JSX.Element | undefined>(undefined);
@@ -42,12 +69,6 @@ export function ApiSupplemental({
     const responseComponentSkeleton = apiComponents.find((apiComponent) => {
       return apiComponent.type === Component.ResponseExample;
     });
-
-    const htmlToReactComponent = (html: string) => {
-      // Convert newlines to breaks to be properly parsed
-      // return parse(html.replaceAll('\n', '<br />'));
-      return parse(html);
-    };
 
     const request: JSX.Element | undefined = requestComponentSkeleton && (
       <RequestExample
@@ -77,7 +98,6 @@ export function ApiSupplemental({
     if (openapi == null) {
       return;
     }
-    const { operation } = getOpenApiOperationMethodAndEndpoint(openapi);
     if (operation?.responses != null) {
       const responseExamplesOpenApi = Object.values(operation?.responses)
         .map((resp: any) => {
@@ -91,7 +111,7 @@ export function ApiSupplemental({
         setOpenApiResponseExamples(responseExamplesOpenApi);
       }
     }
-  }, [openapi]);
+  }, [operation, path]);
 
   useEffect(() => {
     if (openApiResponseExamples.length > 0) {
@@ -152,7 +172,9 @@ export function ApiSupplemental({
 
   return (
     <div className="space-y-6 pb-6">
-      {mdxRequestExample}
+      {mdxRequestExample
+        ? mdxRequestExample
+        : generateRequestExamples(api, apiBaseIndex, paramGroups)}
       {/* TODO - Make it so that you can see both the openapi and response example in 1 view if they're both defined */}
       {highlightedExamples.length === 0 && mdxResponseExample}
       {highlightedExamples.length > 0 && (

--- a/client/src/layouts/ContentsLayout.tsx
+++ b/client/src/layouts/ContentsLayout.tsx
@@ -200,17 +200,14 @@ export function ContentsLayout({
   const { currentSection, registerHeading, unregisterHeading } = useTableOfContents(toc);
   let { prev, next } = usePrevNext();
 
-  const hasApiSupplementalComponents = apiComponents.some(
-    (component: any) => component.type === 'ResponseExample' || component.type === 'RequestExample'
-  );
-
+  const isApi = meta.api || meta.openapi;
   const isWideSize = meta.size === 'wide';
 
   return (
     <div
       className={clsx(
         'relative max-w-3xl mx-auto pt-10 xl:max-w-none xl:ml-0',
-        hasApiSupplementalComponents
+        isApi
           ? 'xl:pr-12 xl:mr-[28rem]'
           : isWideSize
           ? 'xl:pr-20 xl:mr-[12rem]'
@@ -236,21 +233,26 @@ export function ContentsLayout({
 
       {meta.openapi && <OpenApiContent openapi={meta.openapi} auth={meta.auth} />}
 
-      <Footer previous={prev} next={next} hasBottomPadding={!hasApiSupplementalComponents} />
+      <Footer previous={prev} next={next} hasBottomPadding={!isApi} />
       <div
         className={clsx(
           'z-10 hidden xl:block pr-8',
-          hasApiSupplementalComponents
+          isApi
             ? 'w-[30rem] absolute top-[7.6rem] left-full h-full'
             : 'fixed pl-8 w-[21rem] top-[3.8rem] bottom-0 right-[max(0px,calc(50%-45rem))] py-10 overflow-auto'
         )}
       >
-        {!hasApiSupplementalComponents && toc.length > 0 && !isWideSize && (
+        {!isApi && toc.length > 0 && !isWideSize && (
           <TableOfContents tableOfContents={toc} currentSection={currentSection} meta={meta} />
         )}
-        {hasApiSupplementalComponents && (
+        {isApi && (
           <div className="sticky top-[6rem] left-0">
-            <ApiSupplemental openapi={meta.openapi} apiComponents={apiComponents} />
+            <ApiSupplemental
+              apiComponents={apiComponents}
+              api={meta.api}
+              openapi={meta.openapi}
+              auth={meta.auth}
+            />
           </div>
         )}
       </div>

--- a/client/src/layouts/ContentsLayout.tsx
+++ b/client/src/layouts/ContentsLayout.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import { useState, useEffect, createContext, Fragment, useCallback, useContext } from 'react';
 
 import { Heading } from '@/components/Heading';
+import { config } from '@/config';
 import { usePrevNext } from '@/hooks/usePrevNext';
 import { SidebarContext } from '@/layouts/SidebarLayout';
 import { Footer } from '@/ui/Footer';
@@ -251,7 +252,8 @@ export function ContentsLayout({
               apiComponents={apiComponents}
               api={meta.api}
               openapi={meta.openapi}
-              auth={meta.auth}
+              auth={meta.auth ?? config.api?.auth?.method}
+              authName={config.api?.auth?.name}
             />
           </div>
         )}

--- a/client/src/layouts/OpenApiContent.tsx
+++ b/client/src/layouts/OpenApiContent.tsx
@@ -17,7 +17,7 @@ type OpenApiContentProps = {
   auth?: string;
 };
 
-const getAllParameters = (path: any, operation: any) => {
+export const getAllOpenApiParameters = (path: any, operation: any) => {
   return (path.parameters || []).concat(operation.parameters || []);
 };
 
@@ -174,7 +174,7 @@ export function OpenApiContent({ openapi, auth }: OpenApiContentProps) {
 
   let apiComponents: ApiComponent[] = [];
 
-  const parameters = getAllParameters(path, operation);
+  const parameters = getAllOpenApiParameters(path, operation);
 
   const Parameters = parameters.map((parameter: any, i: number) => {
     const { name, description, required, schema, in: paramType, example } = parameter;

--- a/client/src/layouts/SidebarLayout.tsx
+++ b/client/src/layouts/SidebarLayout.tsx
@@ -58,7 +58,7 @@ const NavItem = forwardRef(
     }
 
     if (isGroup(groupPage)) {
-      return <GroupDropdown group={groupPage} level={level} neverNavigateToFirstPage={mobile} />;
+      return <GroupDropdown group={groupPage} level={level} mobile={mobile} />;
     }
 
     const { href, api: pageApi, openapi } = groupPage;
@@ -99,11 +99,11 @@ const NavItem = forwardRef(
 const GroupDropdown = ({
   group,
   level,
-  neverNavigateToFirstPage,
+  mobile,
 }: {
   group: Group;
   level: number;
-  neverNavigateToFirstPage: boolean;
+  mobile: boolean;
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const router = useRouter();
@@ -115,12 +115,12 @@ const GroupDropdown = ({
 
   const onClick = () => {
     // Do not navigate if:
-    // 1. We are on mobile, and thus passed true to neverNavigateToFirstPage.
+    // 1. We are on mobile (users need to a larger space to tap to open the menu)
     // 2. closing
     // 3. The first link is another nested menu
     // 4. The current page is in the nested pages being exposed
     if (
-      !neverNavigateToFirstPage &&
+      !mobile &&
       !isOpen &&
       !isGroup(pages[0]) &&
       pages[0]?.href &&
@@ -160,7 +160,8 @@ const GroupDropdown = ({
           ></path>
         </svg>
       </span>
-      {isOpen && pages.map((subpage) => <NavItem groupPage={subpage} level={level + 1} />)}
+      {isOpen &&
+        pages.map((subpage) => <NavItem groupPage={subpage} level={level + 1} mobile={mobile} />)}
     </>
   );
 };

--- a/client/src/ui/Api.tsx
+++ b/client/src/ui/Api.tsx
@@ -8,7 +8,7 @@ import {
   extractBaseAndPath,
   extractMethodAndEndpoint,
   getApiContext,
-  getParamGroupsFromAPIComponents,
+  getParamGroupsFromApiComponents,
   Param,
   ParamGroup,
 } from '@/utils/api';
@@ -48,7 +48,7 @@ export function Api({
   const { method, endpoint } = extractMethodAndEndpoint(api);
   const { base, path } = extractBaseAndPath(endpoint, apiBaseIndex);
 
-  const paramGroupDict = getParamGroupsFromAPIComponents(apiComponents, auth);
+  const paramGroupDict = getParamGroupsFromApiComponents(apiComponents, auth);
   const paramGroups = Object.entries(paramGroupDict).map(([groupName, params]) => {
     return {
       name: groupName,

--- a/client/src/ui/Api.tsx
+++ b/client/src/ui/Api.tsx
@@ -48,7 +48,14 @@ export function Api({
   const { method, endpoint } = extractMethodAndEndpoint(api);
   const { base, path } = extractBaseAndPath(endpoint, apiBaseIndex);
 
-  const paramGroups = getParamGroupsFromAPIComponents(apiComponents, auth);
+  const paramGroupDict = getParamGroupsFromAPIComponents(apiComponents, auth);
+  const paramGroups = Object.entries(paramGroupDict).map(([groupName, params]) => {
+    return {
+      name: groupName,
+      params,
+    };
+  });
+
   const [currentActiveParamGroup, setCurrentActiveParamGroup] = useState<ParamGroup>(
     paramGroups[0]
   );

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -134,6 +134,8 @@ export const extractMethodAndEndpoint = (
   const endIndexOfMethod = foundMethod ? startIndexOfMethod + foundMethod[0].length - 1 : 0;
   const filename = api.substring(0, startIndexOfMethod).trim();
 
+  // Filename is used when we have multiple openapi files. Filename will be an empty string
+  // for non-openapi pages and openapi pages with a single file.
   return {
     method: foundMethod ? foundMethod[0].slice(0, -1).toUpperCase() : undefined,
     endpoint: api.substring(endIndexOfMethod).trim(),

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -170,7 +170,7 @@ export const extractBaseAndPath = (endpoint: string, apiBaseIndex = 0) => {
 export const getParamGroupsFromAPIComponents = (
   apiComponents?: ApiComponent[],
   auth?: string
-): ParamGroup[] => {
+): Record<string, Param[]> => {
   const groups: Record<string, Param[]> = {};
 
   // Add auth if configured
@@ -265,10 +265,5 @@ export const getParamGroupsFromAPIComponents = (
     }
   });
 
-  return Object.entries(groups).map(([groupName, params]) => {
-    return {
-      name: groupName,
-      params,
-    };
-  });
+  return groups;
 };

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -167,7 +167,7 @@ export const extractBaseAndPath = (endpoint: string, apiBaseIndex = 0) => {
   };
 };
 
-export const getParamGroupsFromAPIComponents = (
+export const getParamGroupsFromApiComponents = (
   apiComponents?: ApiComponent[],
   auth?: string
 ): Record<string, Param[]> => {

--- a/client/src/utils/generateAPIExamples.ts
+++ b/client/src/utils/generateAPIExamples.ts
@@ -1,0 +1,7 @@
+export function generateRequestExamples() {
+  return null;
+}
+
+export function generateResponseExample() {
+  return null;
+}

--- a/client/src/utils/generateAPIExamples.ts
+++ b/client/src/utils/generateAPIExamples.ts
@@ -1,7 +1,0 @@
-export function generateRequestExamples() {
-  return null;
-}
-
-export function generateResponseExample() {
-  return null;
-}

--- a/client/src/utils/generateAPIExamples.tsx
+++ b/client/src/utils/generateAPIExamples.tsx
@@ -53,7 +53,7 @@ export function generateRequestExamples(
   const pythonSnippet = {
     filename: 'Python',
     code:
-      'import requests\n' +
+      'import requests\n\n' +
       `url = "${fullEndpoint}"\n` +
       `headers = {"accept": "application/json"${pythonAuthHeader}}\n` +
       `response = requests.${method?.toLowerCase()}(url, headers=headers)`,

--- a/client/src/utils/generateAPIExamples.tsx
+++ b/client/src/utils/generateAPIExamples.tsx
@@ -1,0 +1,74 @@
+import Prism from 'prismjs';
+import 'prismjs/components/prism-bash';
+import 'prismjs/components/prism-python';
+
+import { RequestExample } from '@/components/ApiExample';
+import { Editor } from '@/components/Editor';
+import { CopyToClipboard } from '@/icons/CopyToClipboard';
+
+import { extractBaseAndPath, extractMethodAndEndpoint, Param } from './api';
+
+export function generateRequestExamples(
+  api: string | undefined,
+  apiBaseIndex: number,
+  params: Record<string, Param[]>
+): JSX.Element | undefined {
+  if (api == null) {
+    return undefined;
+  }
+
+  const { endpoint, method } = extractMethodAndEndpoint(api);
+  const { base, path: endpointPath } = extractBaseAndPath(endpoint, apiBaseIndex);
+  const fullEndpoint = base + endpointPath;
+
+  // \ symbols are escaped otherwise they escape the ` at ends the string
+  const curlSnippet = {
+    filename: 'cURL',
+    code:
+      `curl --request ${method} \\\n` +
+      `     --url ${fullEndpoint} \\\n` +
+      `     --header 'accept: application/json'`,
+    prism: {
+      grammar: Prism.languages.bash,
+      language: 'bash',
+    },
+  };
+
+  const pythonSnippet = {
+    filename: 'Python',
+    code:
+      'import requests\n' +
+      `url = "${fullEndpoint}"\n` +
+      'headers = {"accept": "application/json"}\n' +
+      `response = requests.${method?.toLowerCase()}(url, headers=headers)`,
+    prism: {
+      grammar: Prism.languages.python,
+      language: 'python',
+    },
+  };
+
+  const snippets = [curlSnippet, pythonSnippet];
+
+  return (
+    <RequestExample
+      children={snippets.map((snippet) => {
+        return (
+          <Editor filename={snippet.filename}>
+            <pre>
+              <CopyToClipboard />
+              <code
+                dangerouslySetInnerHTML={{
+                  __html: Prism.highlight(
+                    snippet.code,
+                    snippet.prism.grammar,
+                    snippet.prism.language
+                  ),
+                }}
+              />
+            </pre>
+          </Editor>
+        );
+      })}
+    />
+  );
+}

--- a/client/src/utils/generateAPIExamples.tsx
+++ b/client/src/utils/generateAPIExamples.tsx
@@ -19,7 +19,8 @@ export function generateRequestExamples(
     return undefined;
   }
 
-  console.log(auth);
+  // To do: Generate content for the examples from the params
+  Object.entries(params);
 
   const { endpoint, method } = extractMethodAndEndpoint(api);
   const { base, path: endpointPath } = extractBaseAndPath(endpoint, apiBaseIndex);

--- a/client/src/utils/htmlToReactComponent.ts
+++ b/client/src/utils/htmlToReactComponent.ts
@@ -1,0 +1,7 @@
+import parse from 'html-react-parser';
+
+export const htmlToReactComponent = (html: string) => {
+  // Convert newlines to breaks to be properly parsed
+  // return parse(html.replaceAll('\n', '<br />'));
+  return parse(html);
+};


### PR DESCRIPTION
# Summary

Auto-generates cURL and Python request examples. The request example includes bearer and api-key headers as applicable.

<img width="1058" alt="screenshot of generated example" src="https://user-images.githubusercontent.com/110702161/200011379-ff2bea23-5c88-42bd-8bd9-698d3b0bda81.png">

# Future Functionality
Include parameters in generated examples.
Fill-in bearer token and api-key with the user's input.

# Test Plan
See preview for Vital and Mintlify, and TwelveLabs.

Vital's is very useful because they use OpenAPI and already use RequestExamples -- so we should _not_ override their examples.

Mintlify shows a site without OpenAPI which will now have request examples generated.

TwelveLabs also uses OpenAPI but does not have prefilled request examples, so they are a good test that we still generate them when necessary.