### PR TITLE
Use standard autogenerated examples

### DIFF
--- a/client/src/layouts/ApiSupplemental.tsx
+++ b/client/src/layouts/ApiSupplemental.tsx
@@ -13,14 +13,46 @@ import { generateRequestExamples } from '@/utils/generateAPIExamples';
 import { getOpenApiOperationMethodAndEndpoint } from '@/utils/getOpenApiContext';
 import { htmlToReactComponent } from '@/utils/htmlToReactComponent';
 
-const responseHasExample = (response: any) => {
-  return (
-    response?.content &&
-    response?.content.hasOwnProperty('application/json') &&
-    response?.content['application/json']?.examples &&
-    response?.content['application/json']?.examples.hasOwnProperty(['example-1']) &&
-    response?.content['application/json']?.examples['example-1']?.value
+const responseHasSimpleExample = (response: any): boolean => {
+  if (response?.content == null) {
+    return false;
+  }
+
+  return Boolean(
+    response.content &&
+      response.content.hasOwnProperty('application/json') &&
+      response.content['application/json']?.examples &&
+      response.content['application/json']?.examples.hasOwnProperty(['example-1']) &&
+      response.content['application/json']?.examples['example-1']?.value
   );
+};
+
+const recursivelyConstructExample = (schema: any, result = {}) => {
+  if (schema.example) {
+    return schema.example;
+  }
+
+  if (schema.properties) {
+    const propertiesWithExamples: Record<string, any> = {};
+
+    Object.entries(schema.properties).forEach(([propertyName, propertyValue]): any => {
+      propertiesWithExamples[propertyName] = recursivelyConstructExample(propertyValue);
+    });
+
+    return { result, ...propertiesWithExamples };
+  }
+
+  return result;
+};
+
+const generatedNestedExample = (response: any) => {
+  if (response?.content['application/json']?.schema == null) {
+    return '';
+  }
+
+  const schema = response.content['application/json'].schema;
+
+  return recursivelyConstructExample(schema);
 };
 
 type ApiComponent = {
@@ -50,16 +82,15 @@ export function ApiSupplemental({
     }
   }, []);
 
-  const { operation, path } =
-    openapi != null
-      ? getOpenApiOperationMethodAndEndpoint(openapi)
-      : { operation: undefined, path: undefined };
   //const parameters = getAllOpenApiParameters(path, operation);
   const paramGroups = getParamGroupsFromApiComponents(apiComponents, auth);
 
   // Response and Request Examples from MDX
   const [mdxRequestExample, setMdxRequestExample] = useState<JSX.Element | undefined>(undefined);
   const [mdxResponseExample, setMdxResponseExample] = useState<JSX.Element | undefined>(undefined);
+  // Open API generated response examples
+  const [openApiResponseExamples, setOpenApiResponseExamples] = useState<string[]>([]);
+
   useEffect(() => {
     const requestComponentSkeleton = apiComponents.find((apiComponent) => {
       return apiComponent.type === Component.RequestExample;
@@ -89,8 +120,6 @@ export function ApiSupplemental({
 
     setMdxResponseExample(response);
   }, [apiComponents]);
-  // Open API generated response examples
-  const [openApiResponseExamples, setOpenApiResponseExamples] = useState<string[]>([]);
 
   useEffect(() => {
     if (openapi == null) {
@@ -99,11 +128,11 @@ export function ApiSupplemental({
     const { operation } = getOpenApiOperationMethodAndEndpoint(openapi);
     if (operation?.responses != null) {
       const responseExamplesOpenApi = Object.values(operation?.responses)
-        .map((resp: any) => {
-          if (responseHasExample(resp)) {
-            return resp?.content['application/json']?.examples['example-1']?.value;
+        .map((res: any) => {
+          if (responseHasSimpleExample(res)) {
+            return res?.content['application/json']?.examples['example-1']?.value;
           }
-          return '';
+          return generatedNestedExample(res);
         })
         .filter((example) => example !== '');
       if (responseExamplesOpenApi != null) {

--- a/client/src/layouts/ApiSupplemental.tsx
+++ b/client/src/layouts/ApiSupplemental.tsx
@@ -223,8 +223,8 @@ export function ApiSupplemental({
     <div className="space-y-6 pb-6">
       {requestExamples}
       {/* TODO - Make it so that you can see both the openapi and response example in 1 view if they're both defined */}
-      {openApiResponseExamples.length === 0 && mdxResponseExample}
-      {openApiResponseExamples.length > 0 && (
+      {mdxResponseExample}
+      {!mdxResponseExample && openApiResponseExamples.length > 0 && (
         <ResponseExample
           children={{
             props: {

--- a/client/src/layouts/ApiSupplemental.tsx
+++ b/client/src/layouts/ApiSupplemental.tsx
@@ -64,12 +64,14 @@ const recursivelyCheckIfHasExample = (schema: any) => {
 };
 
 const generatedNestedExample = (response: any) => {
-  if (response?.content['application/json']?.schema == null) {
+  if (
+    response?.content?.hasOwnProperty('application/json') == null ||
+    response.content['application/json']?.schema == null
+  ) {
     return '';
   }
 
   const schema = response.content['application/json'].schema;
-  console.log(schema);
   const constructedExample = recursivelyConstructExample(schema);
   const hasExample = recursivelyCheckIfHasExample(schema);
 

--- a/client/src/layouts/ApiSupplemental.tsx
+++ b/client/src/layouts/ApiSupplemental.tsx
@@ -27,7 +27,7 @@ const responseHasSimpleExample = (response: any): boolean => {
   );
 };
 
-const recursivelyConstructExample = (schema: any, result = {}) => {
+const recursivelyConstructExample = (schema: any, result = {}): any => {
   if (schema.example) {
     return schema.example;
   }
@@ -39,10 +39,14 @@ const recursivelyConstructExample = (schema: any, result = {}) => {
       propertiesWithExamples[propertyName] = recursivelyConstructExample(propertyValue);
     });
 
-    return { result, ...propertiesWithExamples };
+    return { ...result, ...propertiesWithExamples };
   }
 
-  return result;
+  if (schema.items) {
+    return [recursivelyConstructExample(schema.items)];
+  }
+
+  return schema.type ?? null;
 };
 
 const recursivelyCheckIfHasExample = (schema: any) => {
@@ -65,6 +69,7 @@ const generatedNestedExample = (response: any) => {
   }
 
   const schema = response.content['application/json'].schema;
+  console.log(schema);
   const constructedExample = recursivelyConstructExample(schema);
   const hasExample = recursivelyCheckIfHasExample(schema);
 

--- a/client/src/layouts/ApiSupplemental.tsx
+++ b/client/src/layouts/ApiSupplemental.tsx
@@ -45,14 +45,34 @@ const recursivelyConstructExample = (schema: any, result = {}) => {
   return result;
 };
 
+const recursivelyCheckIfHasExample = (schema: any) => {
+  if (schema.example) {
+    return true;
+  }
+
+  if (schema.properties) {
+    return Object.values(schema.properties).some((propertyValue): any => {
+      return recursivelyCheckIfHasExample(propertyValue);
+    });
+  }
+
+  return false;
+};
+
 const generatedNestedExample = (response: any) => {
   if (response?.content['application/json']?.schema == null) {
     return '';
   }
 
   const schema = response.content['application/json'].schema;
+  const constructedExample = recursivelyConstructExample(schema);
+  const hasExample = recursivelyCheckIfHasExample(schema);
 
-  return recursivelyConstructExample(schema);
+  if (hasExample) {
+    return constructedExample;
+  }
+
+  return '';
 };
 
 type ApiComponent = {


### PR DESCRIPTION
# Summary

- Extend auto-generated OpenAPI to normal schema-based types

# Test Plan

- Check that deployments using OpenAPI have a reasonably generated response example section
- Check that custom response exampels override default ones