### PR TITLE
Han/min 1087 markdown support for parameter

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -94,6 +94,7 @@
     "react-hotjar": "^5.1.0",
     "react-hotkeys-hook": "^3.4.7",
     "react-intersection-observer": "^8.29.0",
+    "react-markdown": "^8.0.3",
     "react-use-intercom": "^2.0.0",
     "react-use-rect": "^2.0.4",
     "redent": "^3.0.0",

--- a/client/src/layouts/OpenApiContent.tsx
+++ b/client/src/layouts/OpenApiContent.tsx
@@ -1,6 +1,7 @@
 // TODO: Refactor this file to improve readability
 import { Tab, Tabs } from '@mintlify/components';
 import { useEffect, useState, useContext } from 'react';
+import ReactMarkdown from 'react-markdown';
 
 import { Expandable } from '@/components/Expandable';
 import { Heading } from '@/components/Heading';
@@ -14,6 +15,10 @@ import { createExpandable, createParamField, getProperties } from '@/utils/opena
 type OpenApiContentProps = {
   endpointStr: string;
   auth?: string;
+};
+
+const MarkdownComponents = {
+  p: (props: any) => <p className="m-0" {...props} />,
 };
 
 export const getAllOpenApiParameters = (path: any, operation: any) => {
@@ -72,7 +77,7 @@ function ExpandableFields({ schema }: any) {
     return (
       <ResponseField name={name} type={schema.items.type}>
         <>
-          {schema.description}
+          <ReactMarkdown components={MarkdownComponents}>{schema.description}</ReactMarkdown>
           <Expandable
             title="properties"
             defaultOpen={false}
@@ -121,7 +126,9 @@ function ExpandableFields({ schema }: any) {
                 {/* Is array nested */}
                 {value.items && !isArrayExpandable ? (
                   <div className="mt-2">
-                    {value.description}
+                    <ReactMarkdown components={MarkdownComponents}>
+                      {value.description}
+                    </ReactMarkdown>
                     <Expandable
                       title={value.items.type || 'properties'}
                       onChange={(open) => {
@@ -134,7 +141,9 @@ function ExpandableFields({ schema }: any) {
                   </div>
                 ) : (
                   <>
-                    {value.description || value.title || getEnumDescription(value.enum)}
+                    <ReactMarkdown components={MarkdownComponents}>
+                      {value.description || value.title || getEnumDescription(value.enum)}
+                    </ReactMarkdown>
                     {value.properties && (
                       <div className="mt-2">
                         <Expandable
@@ -199,7 +208,9 @@ export function OpenApiContent({ endpointStr, auth }: OpenApiContentProps) {
         default={schema?.default}
         enum={schema?.enum}
       >
-        {description || schema?.description || schema?.title}
+        <ReactMarkdown components={MarkdownComponents}>
+          {description || schema?.description || schema?.title}
+        </ReactMarkdown>
       </ParamField>
     );
   });
@@ -246,7 +257,9 @@ export function OpenApiContent({ endpointStr, auth }: OpenApiContentProps) {
           enum={propertyValue.enum}
           last={last}
         >
-          {propertyValue.description || propertyValue.title}
+          <ReactMarkdown components={MarkdownComponents}>
+            {propertyValue.description || propertyValue.title}
+          </ReactMarkdown>
         </ParamField>
       );
     });

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2520,7 +2520,7 @@
   resolved "https://registry.yarnpkg.com/@types/prismjs/-/prismjs-1.26.0.tgz#a1c3809b0ad61c62cac6d4e0c56d610c910b7654"
   integrity sha512-ZTaqn/qSqUuAq1YwvOFQfVW1AR/oQJlLSZVustdjwI+GZ8kr0MSHBj0tsXPW1EqHubx50gtBEjbPGsdZwQwCjQ==
 
-"@types/prop-types@*":
+"@types/prop-types@*", "@types/prop-types@^15.0.0":
   version "15.7.5"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
@@ -7452,7 +7452,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.8.1:
+prop-types@^15.0.0, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -7542,6 +7542,27 @@ react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
+react-markdown@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-8.0.3.tgz#e8aba0d2f5a1b2124d476ee1fff9448a2f57e4b3"
+  integrity sha512-We36SfqaKoVNpN1QqsZwWSv/OZt5J15LNgTLWynwAN5b265hrQrsjMtlRNwUvS+YyR3yDM8HpTNc4pK9H/Gc0A==
+  dependencies:
+    "@types/hast" "^2.0.0"
+    "@types/prop-types" "^15.0.0"
+    "@types/unist" "^2.0.0"
+    comma-separated-tokens "^2.0.0"
+    hast-util-whitespace "^2.0.0"
+    prop-types "^15.0.0"
+    property-information "^6.0.0"
+    react-is "^18.0.0"
+    remark-parse "^10.0.0"
+    remark-rehype "^10.0.0"
+    space-separated-tokens "^2.0.0"
+    style-to-object "^0.3.0"
+    unified "^10.0.0"
+    unist-util-visit "^4.0.0"
+    vfile "^5.0.0"
 
 react-property@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
# Summary

This PR enables vanilla markdown support for OpenAPI param and response field descriptions

<img width="1440" alt="Screen Shot 2022-11-25 at 12 29 12 AM" src="https://user-images.githubusercontent.com/44352119/203935812-52e01b3d-99e3-4c29-a00f-eb8fcd934a0e.png">

# Test Plan

- Make sure that normal openapi descriptions aren't affected
- Go to TwelveLabs -> V2 -> API Reference -> Engines and see that it's markdown enabled