### PR TITLE
Match anchor styling to the search bar

### DIFF
--- a/client/src/components/Heading.tsx
+++ b/client/src/components/Heading.tsx
@@ -66,7 +66,7 @@ export function Heading({
           aria-label="Navigate to header"
         >
           &#8203;
-          <div className="w-6 h-6 text-slate-400 ring-1 ring-slate-900/5 rounded-md shadow-sm flex items-center justify-center hover:ring-slate-900/10 hover:shadow hover:text-slate-700 dark:bg-slate-700 dark:text-slate-300 dark:shadow-none dark:ring-0">
+          <div className="w-6 h-6 text-zinc-400 rounded-md flex items-center justify-center zinc-box">
             <svg
               className="h-4 w-4"
               fill="currentColor"

--- a/client/src/css/components.css
+++ b/client/src/css/components.css
@@ -1,0 +1,7 @@
+@import 'tailwindcss/components';
+
+@layer components {
+  .zinc-box {
+    @apply shadow-sm text-zinc-400 dark:text-white/50 ring-1 ring-slate-500/10 bg-zinc-50 hover:ring-slate-900/20 dark:hover:ring-white/10 dark:bg-background-dark dark:brightness-[1.35] dark:ring-1 dark:hover:brightness-150;
+  }
+}

--- a/client/src/css/main.css
+++ b/client/src/css/main.css
@@ -6,5 +6,5 @@
 @import 'bar-of-progress.css';
 /*! purgecss end ignore */
 
-@import 'tailwindcss/components';
+@import 'components.css';
 @import 'utilities.css';

--- a/client/src/pages/404.tsx
+++ b/client/src/pages/404.tsx
@@ -3,14 +3,12 @@ export function ErrorPage() {
     <main className="h-screen dark:bg-[#0f1117]">
       <article className="bg-custom bg-fixed bg-center bg-cover relative flex flex-col items-center justify-center h-full">
         <div className="w-full max-w-xl px-10">
-          <span className="inline-flex mb-6 rounded-full px-3 py-1 text-sm font-semibold mr-4 text-white ring-green-900/5 group-hover:ring-green-900/10 dark:group-hover:highlight-white/10 p-1 highlight-slate-700/5 bg-[#117866] dark:highlight-white/5">
+          <span className="inline-flex mb-6 rounded-full px-3 py-1 text-sm font-semibold mr-4 text-white ring-green-900/5 group-hover:ring-green-900/10 p-1 bg-[#117866]">
             Error&nbsp;404
           </span>
-          <h1 className="font-semibold mb-3 text-3xl">
-            Well this is embarrassing…
-          </h1>
+          <h1 className="font-semibold mb-3 text-3xl">Well this is embarrassing…</h1>
           <p className="text-lg text-slate-500 dark:text-slate-400 mb-6">
-            We can't find the page you are looking for. Please <a href="mailto:hi@mintlify.com" className="font-medium text-slate-700 dark:text-gray-100 border-b hover:border-b-[2px] border-[#2AB673] dark:border-[#117866]">contact support</a> or go to <a href="https://mintlify.com" className="font-medium text-slate-700 dark:text-gray-100 border-b hover:border-b-[2px] border-[#2AB673] dark:border-[#117866]">mintlify.com</a> to find what you&nbsp;need.
+            We can't find the page you are looking for.
           </p>
         </div>
       </article>

--- a/client/src/ui/AnchorLink.tsx
+++ b/client/src/ui/AnchorLink.tsx
@@ -51,11 +51,11 @@ const Anchor = forwardRef(
               : {}
           }
           className={clsx(
-            `mr-4 rounded-md ring-slate-900/5 group-hover:ring-slate-900/10 dark:group-hover:highlight-white/10 p-1`,
+            `mr-4 rounded-md p-1`,
             !color && 'group-hover:bg-primary',
             isActive
               ? [color ? '' : 'bg-primary', 'highlight-slate-700/10 dark:highlight-white/10']
-              : 'bg-slate-300 highlight-slate-700/5 dark:bg-slate-800 dark:highlight-white/5'
+              : 'zinc-box'
           )}
         >
           {icon}
@@ -102,8 +102,8 @@ export function StyledAnchorLink({
         icon={icon.toLowerCase()}
         iconType="duotone"
         className={clsx(
-          `h-4 w-4 bg-white secondary-opacity group-hover:fill-primary-dark dark:group-hover:bg-white`,
-          isActive ? 'dark:bg-white' : 'dark:bg-slate-500'
+          `h-4 w-4 secondary-opacity group-hover:fill-primary-dark group-hover:bg-white`,
+          isActive ? 'bg-white' : 'bg-zinc-400 dark:bg-zinc-500'
         )}
       />
     );

--- a/client/src/ui/AnchorLink.tsx
+++ b/client/src/ui/AnchorLink.tsx
@@ -55,7 +55,7 @@ const Anchor = forwardRef(
             !color && 'group-hover:bg-primary',
             isActive
               ? [color ? '' : 'bg-primary', 'highlight-slate-700/10 dark:highlight-white/10']
-              : 'zinc-box'
+              : 'zinc-box group-hover:brightness-100 group-hover:ring-0'
           )}
         >
           {icon}

--- a/client/src/ui/AnchorLink.tsx
+++ b/client/src/ui/AnchorLink.tsx
@@ -54,7 +54,7 @@ const Anchor = forwardRef(
             `mr-4 rounded-md p-1`,
             !color && 'group-hover:bg-primary',
             isActive
-              ? [color ? '' : 'bg-primary', 'highlight-slate-700/10 dark:highlight-white/10']
+              ? [color ? '' : 'bg-primary']
               : 'zinc-box group-hover:brightness-100 group-hover:ring-0'
           )}
         >

--- a/client/src/ui/Header.tsx
+++ b/client/src/ui/Header.tsx
@@ -178,7 +178,7 @@ function TopBarCtaButton({ button }: { button: TopbarCta }) {
       <Link
         href={button.url ?? '/'}
         target="_blank"
-        className="relative inline-flex items-center space-x-2 px-4 py-1.5 shadow-sm text-sm font-medium rounded-full text-white bg-primary-dark hover:bg-primary-ultradark dark:highlight-white/5"
+        className="relative inline-flex items-center space-x-2 px-4 py-1.5 shadow-sm text-sm font-medium rounded-full text-white bg-primary-dark hover:bg-primary-ultradark"
       >
         <span>{button.name}</span>
         <svg width="6" height="3" className="h-2 overflow-visible -rotate-90" aria-hidden="true">

--- a/client/src/ui/Header.tsx
+++ b/client/src/ui/Header.tsx
@@ -296,7 +296,7 @@ export function Header({
                 <VersionSelect />
               </div>
               <div className="relative flex-none bg-white lg:w-64 xl:w-80 dark:bg-slate-900 pointer-events-auto rounded-md">
-                <SearchButton className="hidden w-full lg:flex items-center text-sm leading-6 text-zinc-400 dark:text-white/50 rounded-md ring-1 ring-slate-500/10 shadow-sm py-1.5 pl-2 pr-3 bg-zinc-50 hover:ring-slate-900/20 dark:hover:ring-white/10 dark:bg-background-dark dark:brightness-[1.35] dark:ring-1 dark:hover:brightness-150">
+                <SearchButton className="hidden w-full lg:flex items-center text-sm leading-6 rounded-md py-1.5 pl-2 pr-3 zinc-box">
                   {({ actionKey }: any) => (
                     <>
                       <Icon

--- a/client/src/ui/search/Search.tsx
+++ b/client/src/ui/search/Search.tsx
@@ -87,7 +87,7 @@ function SearchHit({
       <>
         <div
           className={clsx(
-            'rounded-md ring-1 ring-slate-900/5 shadow-sm group-hover:shadow group-hover:ring-slate-900/10 dark:ring-0 dark:shadow-none dark:group-hover:shadow-none dark:group-hover:highlight-white/10',
+            'rounded-md ring-1 ring-slate-900/5 shadow-sm group-hover:shadow group-hover:ring-slate-900/10 dark:ring-0 dark:shadow-none dark:group-hover:shadow-none',
             active ? 'bg-white dark:bg-primary' : 'dark:bg-slate-800'
           )}
         >
@@ -136,7 +136,7 @@ function SearchHit({
       <>
         <div
           className={clsx(
-            'rounded-md ring-1 ring-slate-900/5 shadow-sm group-hover:shadow group-hover:ring-slate-900/10 dark:ring-0 dark:shadow-none dark:group-hover:shadow-none dark:group-hover:highlight-white/10',
+            'rounded-md ring-1 ring-slate-900/5 shadow-sm group-hover:shadow group-hover:ring-slate-900/10 dark:ring-0 dark:shadow-none dark:group-hover:shadow-none',
             active ? 'bg-white dark:bg-primary' : 'dark:bg-slate-800'
           )}
         >
@@ -184,7 +184,7 @@ function SearchHit({
     <>
       <div
         className={clsx(
-          'rounded-md ring-1 ring-slate-900/5 shadow-sm group-hover:shadow group-hover:ring-slate-900/10 dark:ring-0 dark:shadow-none dark:group-hover:shadow-none dark:group-hover:highlight-white/10',
+          'rounded-md ring-1 ring-slate-900/5 shadow-sm group-hover:shadow group-hover:ring-slate-900/10 dark:ring-0 dark:shadow-none dark:group-hover:shadow-none',
           active ? 'bg-white dark:bg-primary' : 'dark:bg-slate-800'
         )}
       >

--- a/client/tailwind.config.cjs
+++ b/client/tailwind.config.cjs
@@ -302,12 +302,7 @@ module.exports = {
         { values: flattenColorPalette(theme('backgroundColor')), type: 'color' }
       );
 
-      matchUtilities(
-        {
-          highlight: (value) => ({ boxShadow: `inset 0 1px 0 0 ${value}` }),
-        },
-        { values: flattenColorPalette(theme('backgroundColor')), type: 'color' }
-      );
+      matchUtilities({ values: flattenColorPalette(theme('backgroundColor')), type: 'color' });
     },
   ],
   safelist: [


### PR DESCRIPTION
Updates the anchor styling to use the same classes as the search bar.
<img width="738" alt="new light" src="https://user-images.githubusercontent.com/110702161/207955446-df80f5dd-13e4-4d7b-bd32-a27cb283388d.png">
<img width="726" alt="new-dark" src="https://user-images.githubusercontent.com/110702161/207955498-578ba025-3d09-42bc-b999-15a5c80bba01.png">
