### PR TITLE
Darken anchor borders

### DIFF
--- a/client/src/css/components.css
+++ b/client/src/css/components.css
@@ -2,6 +2,6 @@
 
 @layer components {
   .zinc-box {
-    @apply shadow-sm text-zinc-400 dark:text-white/50 ring-1 ring-slate-500/10 bg-zinc-50 hover:ring-slate-900/20 dark:hover:ring-white/10 dark:bg-background-dark dark:brightness-[1.35] dark:ring-1 dark:hover:brightness-150;
+    @apply shadow-sm text-zinc-400 dark:text-white/50 ring-1 ring-slate-500/30 bg-zinc-50 hover:ring-slate-900/50 dark:hover:ring-white/10 dark:bg-background-dark dark:brightness-[1.35] dark:ring-1 dark:hover:brightness-150;
   }
 }

--- a/client/src/ui/AnchorLink.tsx
+++ b/client/src/ui/AnchorLink.tsx
@@ -50,7 +50,7 @@ const Anchor = forwardRef(
               : {}
           }
           className={clsx(
-            `mr-4 rounded-md p-1`,
+            'mr-4 rounded-md p-1',
             !color && 'group-hover:bg-primary',
             isActive
               ? [color ? '' : 'bg-primary']
@@ -107,14 +107,7 @@ export function StyledAnchorLink({
       />
     );
   return (
-    <AnchorLink
-      {...props}
-      as={as}
-      href={href}
-      icon={AnchorIcon}
-      isActive={isActive}
-      color={color}
-    >
+    <AnchorLink {...props} as={as} href={href} icon={AnchorIcon} isActive={isActive} color={color}>
       {name ?? href}
     </AnchorLink>
   );


### PR DESCRIPTION
Darkens borders on light mode to make it clear anchors are interactive.
<img width="163" alt="Screen Shot 2022-12-16 at 10 03 01 AM" src="https://user-images.githubusercontent.com/110702161/208126920-44b68ae1-d96b-4a82-a1bb-9e130d236226.png">
