### PR TITLE
Use blocking for font and fix dark mode

### DIFF
--- a/client/src/layouts/SupremePageLayout.tsx
+++ b/client/src/layouts/SupremePageLayout.tsx
@@ -98,7 +98,7 @@ export default function SupremePageLayout({
               dangerouslySetInnerHTML={{
                 __html: `
                 try {
-                  if (localStorage.isDarkMode === true || (${(
+                  if (localStorage.isDarkMode === 'true' || (${(
                     config.modeToggle?.default == null
                   ).toString()} && !('isDarkMode' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches) || ${(
                   config.modeToggle?.default === 'dark'

--- a/client/src/layouts/SupremePageLayout.tsx
+++ b/client/src/layouts/SupremePageLayout.tsx
@@ -7,6 +7,7 @@ import { useState, useEffect } from 'react';
 import AnalyticsContext from '@/analytics/AnalyticsContext';
 import GA4Script from '@/analytics/GA4Script';
 import GTMScript from '@/analytics/GTMScript';
+import PlausibleScript from '@/analytics/PlausibleScript';
 import { useAnalytics } from '@/analytics/useAnalytics';
 import components from '@/components';
 import { ConfigContext } from '@/context/ConfigContext';
@@ -21,7 +22,6 @@ import { ColorVariables } from '@/ui/ColorVariables';
 import { FeedbackProvider } from '@/ui/Feedback';
 import { SearchProvider } from '@/ui/search/Search';
 import { getAnalyticsConfig } from '@/utils/getAnalyticsConfig';
-import PlausibleScript from '@/analytics/PlausibleScript';
 
 // First Layout used by every page inside [[..slug]]
 export default function SupremePageLayout({
@@ -98,15 +98,13 @@ export default function SupremePageLayout({
               dangerouslySetInnerHTML={{
                 __html: `
                 try {
-                  if (localStorage.isDarkMode === 'dark' || (${(
+                  if (localStorage.isDarkMode === true || (${(
                     config.modeToggle?.default == null
                   ).toString()} && !('isDarkMode' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches) || ${(
                   config.modeToggle?.default === 'dark'
                 ).toString()}) {
                     document.documentElement.classList.add('dark')
-                  }
-                  
-                  else {
+                  } else {
                     document.documentElement.classList.remove('dark')
                   }
                 } catch (_) {}

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -6,8 +6,7 @@ import ErrorBoundary from '@/ui/ErrorBoundary';
 import '../css/main.css';
 
 const inter = Inter({
-  display: 'swap',
-  fallback: ['arial'],
+  display: 'block',
   subsets: ['latin'],
   variable: '--font-inter',
 });


### PR DESCRIPTION
Blocking will require the font to load before the site can be displayed, preventing flashing when the correct font is loaded.

Dark mode bug was caused by us storing `isDarkMode` as a boolean but our script was using strings.