### PR TITLE
Add "Wide Mode" to Page docs

### DIFF
--- a/docs/settings/page.mdx
+++ b/docs/settings/page.mdx
@@ -72,10 +72,23 @@ You can show a different title in the navigation with the `sidebarTitle` metadat
 
 <CodeGroup>
 
-```md Schema
+```md Sidebar Title Example
 ---
 title: "Your very long page title you want to shorten"
 sidebarTitle: "Short title"
+---
+```
+  
+## Wide Mode
+
+You can hide the headings preview on the right side of the page. This is useful if you don't have any headings, or you want to take advantage of the extra horizontal space.
+
+<CodeGroup>
+
+```md Wide Mode Example
+---
+title: "Your page with no headings"
+mode: "wide"
 ---
 ```
 


### PR DESCRIPTION
# Summary

Add a section to the Page docs to describe `mode: "wide"`

# Test Plan
