### PR TITLE
Open Anchors in new tab, move them to Next 13 Link component

### DIFF
--- a/client/src/components/DynamicLink.tsx
+++ b/client/src/components/DynamicLink.tsx
@@ -1,10 +1,37 @@
 import Link from 'next/link';
 
-export function DynamicLink({ href, children }: { href?: string; children?: any }) {
+export function DynamicLink({
+  href,
+  ref,
+  onClick,
+  onMouseEnter,
+  onMouseLeave,
+  style,
+  className,
+  children,
+}: {
+  href?: string;
+  ref: any;
+  onClick?: (el: any) => void;
+  onMouseEnter?: any;
+  onMouseLeave?: any;
+  style?: any;
+  className?: string;
+  children?: any;
+}) {
   if (href?.startsWith('/') || href?.startsWith('#')) {
     // next/link is used for internal links to avoid extra network calls
     return (
-      <Link href={href} passHref={true}>
+      <Link
+        href={href}
+        ref={ref}
+        passHref={true}
+        onClick={onClick}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+        style={style}
+        className={className}
+      >
         {children}
       </Link>
     );
@@ -12,11 +39,33 @@ export function DynamicLink({ href, children }: { href?: string; children?: any 
 
   if (href?.startsWith('./') || href?.startsWith('../')) {
     // Cannot use a Link, it doesn't work because it would be relative to the [[...slug]] file
-    return <a href={href}>{children}</a>;
+    return (
+      <a
+        href={href}
+        ref={ref}
+        onClick={onClick}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+        style={style}
+        className={className}
+      >
+        {children}
+      </a>
+    );
   }
 
   return (
-    <a href={href} target="_blank" rel="noreferrer">
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      ref={ref}
+      onClick={onClick}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      style={style}
+      className={className}
+    >
       {children}
     </a>
   );

--- a/client/src/ui/AnchorLink.tsx
+++ b/client/src/ui/AnchorLink.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
-import Link from 'next/link';
-import { forwardRef, useState } from 'react';
+import { ForwardedRef, forwardRef, useState } from 'react';
+
+import { DynamicLink } from '@/components/DynamicLink';
 
 import Icon from './Icon';
 
@@ -19,12 +20,12 @@ type TopLevelProps = {
 };
 
 const Anchor = forwardRef(
-  ({ children, href, className, icon, isActive, onClick, color }: TopLevelProps, ref: any) => {
+  ({ children, href, icon, isActive, onClick, color }: TopLevelProps, ref: ForwardedRef<any>) => {
     const [hovering, setHovering] = useState(false);
     const usePrimaryColorForText = color == null || color.includes('linear-gradient');
 
     return (
-      <a
+      <DynamicLink
         ref={ref}
         href={href}
         onClick={onClick}
@@ -60,29 +61,10 @@ const Anchor = forwardRef(
           {icon}
         </div>
         {children}
-      </a>
+      </DynamicLink>
     );
   }
 );
-
-export function AnchorLink({ ...props }: TopLevelProps) {
-  const { href } = props;
-  if (/^https?:\/\//.test(href)) {
-    return (
-      <li>
-        <Anchor {...props} />
-      </li>
-    );
-  }
-
-  return (
-    <li>
-      <Link href={href ?? '/'} legacyBehavior>
-        <Anchor {...props} />
-      </Link>
-    </li>
-  );
-}
 
 export function StyledAnchorLink({
   href,
@@ -107,8 +89,17 @@ export function StyledAnchorLink({
       />
     );
   return (
-    <AnchorLink {...props} as={as} href={href} icon={AnchorIcon} isActive={isActive} color={color}>
-      {name ?? href}
-    </AnchorLink>
+    <li>
+      <Anchor
+        {...props}
+        as={as}
+        href={href ?? '/'}
+        icon={AnchorIcon}
+        isActive={isActive}
+        color={color}
+      >
+        {name ?? href}
+      </Anchor>
+    </li>
   );
 }


### PR DESCRIPTION
Open anchors in a new tab when they link externally. Accomplished by expanding the DynamicLink component to take in more props that it flows through to Link.