### PR TITLE
Reduce topAnchor validation to just the name

### DIFF
--- a/client/src/types/config.ts
+++ b/client/src/types/config.ts
@@ -84,6 +84,7 @@ export type Config = {
   navigation?: Navigation[];
   topAnchor?: {
     name: string;
+    icon?: string;
   };
   anchors?: Anchor[];
   footerSocials?: FooterSocial[] | FooterSocials;

--- a/client/src/types/config.ts
+++ b/client/src/types/config.ts
@@ -1,4 +1,5 @@
 import { AnalyticsMediatorConstructorInterface } from '@/analytics/AnalyticsMediator';
+
 import { Gradient } from './gradient';
 
 export type NavigationEntry = string | Navigation;
@@ -81,7 +82,9 @@ export type Config = {
   topbarCtaButton?: NavbarLink;
   topbarLinks?: NavbarLink[];
   navigation?: Navigation[];
-  topAnchor?: Anchor;
+  topAnchor?: {
+    name: string;
+  };
   anchors?: Anchor[];
   footerSocials?: FooterSocial[] | FooterSocials;
   backgroundImage?: string;

--- a/client/src/utils/getAllMetaTags.ts
+++ b/client/src/utils/getAllMetaTags.ts
@@ -26,6 +26,7 @@ export function getAllMetaTags(pageMeta: PageMetaTags, configMetadata: { [key: s
     'og:type': 'website',
     'og:title': defaultTitle(pageMeta, configMetadata.name),
     'twitter:title': defaultTitle(pageMeta, configMetadata.name),
+    'og:description': pageMeta.description,
   } as { [key: string]: any };
   SEO_META_TAGS.forEach((tagName) => {
     const metaValue = pageMeta[tagName] ?? configMetadata[tagName];

--- a/docs/settings/global.mdx
+++ b/docs/settings/global.mdx
@@ -149,10 +149,13 @@ Example: `mintlify`
 </ResponseField>
 
 <ResponseField name="topAnchor" type="Object">
-  Override the default configurations for the top-most anchor
+  Override the default configurations for the top-most anchor.
   <Expandable title="Object">
     <ResponseField name="name" default="Documentation" type="string">
       The name of the top-most anchor
+    </ResponseField>
+    <ResponseField name="icon" default="book-open" type="string">
+      Font Awesome icon.
     </ResponseField>
   </Expandable>
 </ResponseField>

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintlify/validation",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Validates mint.json files",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/validation/src/schemas/colors.ts
+++ b/packages/validation/src/schemas/colors.ts
@@ -2,56 +2,64 @@ import { z } from "zod";
 import { anchorColorSchema } from "./anchorColors";
 import { hexadecimalPattern } from "../utils/hexadecimalPattern";
 
-export const colorsSchema = z.object(
-  {
-    primary: z
-      .string({ invalid_type_error: "Primary color must be a string." })
-      .min(1, "Color primary is missing.")
-      .regex(
-        hexadecimalPattern,
-        "Primary color must be a hexadecimal color including the # at the start."
-      ),
-    light: z
-      .string({ invalid_type_error: "Light color must be a string." })
-      .regex(
-        hexadecimalPattern,
-        "Light color must be a hexadecimal color including the # at the start."
-      )
-      .optional(),
-    dark: z
-      .string({ invalid_type_error: "Dark color must be a string." })
-      .regex(
-        hexadecimalPattern,
-        "Dark color must be a hexadecimal color including the # at the start."
-      )
-      .optional(),
-    background: z
-      .object({
-        light: z
-          .string({
-            invalid_type_error: "Background light color must be a string.",
-          })
-          .regex(
-            hexadecimalPattern,
-            "Background light color must be a hexadecimal color including the # at the start."
-          )
-          .optional(),
-        dark: z
-          .string({
-            invalid_type_error: "Background dark color must be a string.",
-          })
-          .regex(
-            hexadecimalPattern,
-            "Background dark color must be a hexadecimal color including the # at the start."
-          )
-          .optional(),
-      })
-      .optional(),
-    anchors: anchorColorSchema.optional(),
-  },
-  {
-    required_error:
-      'Colors are missing. You need to define at least the primary color. For example: { "colors": { "primary": "#ff0000" } }',
-    invalid_type_error: "Colors must be an object.",
-  }
-);
+export const colorsSchema = z
+  .object(
+    {
+      primary: z
+        .string({ invalid_type_error: "Primary color must be a string." })
+        .min(1, "Color primary is missing.")
+        .regex(
+          hexadecimalPattern,
+          "Primary color must be a hexadecimal color including the # at the start."
+        ),
+      light: z
+        .string({ invalid_type_error: "Light color must be a string." })
+        .regex(
+          hexadecimalPattern,
+          "Light color must be a hexadecimal color including the # at the start."
+        )
+        .optional(),
+      dark: z
+        .string({ invalid_type_error: "Dark color must be a string." })
+        .regex(
+          hexadecimalPattern,
+          "Dark color must be a hexadecimal color including the # at the start."
+        )
+        .optional(),
+      background: z
+        .object({
+          light: z
+            .string({
+              invalid_type_error: "Background light color must be a string.",
+            })
+            .regex(
+              hexadecimalPattern,
+              "Background light color must be a hexadecimal color including the # at the start."
+            )
+            .optional(),
+          dark: z
+            .string({
+              invalid_type_error: "Background dark color must be a string.",
+            })
+            .regex(
+              hexadecimalPattern,
+              "Background dark color must be a hexadecimal color including the # at the start."
+            )
+            .optional(),
+        })
+        .optional(),
+      anchors: anchorColorSchema.optional(),
+
+      // Prevent strict() from throwing an error when the user defines a deprecated ultraLight / ultraDark color.
+      ultraLight: z.any().optional(),
+      ultraDark: z.any().optional(),
+    },
+    {
+      required_error:
+        'Colors are missing. You need to define at least the primary color. For example: { "colors": { "primary": "#ff0000" } }',
+      invalid_type_error: "Colors must be an object.",
+    }
+  )
+  .strict(
+    "Some of the colors in mint.json are invalid, did you make a typo? We only accept primary, light, dark, background, and anchors."
+  );

--- a/packages/validation/src/schemas/config.ts
+++ b/packages/validation/src/schemas/config.ts
@@ -177,17 +177,13 @@ export const configSchema = z.object({
             "topAnchor.name is missing, set it or delete the entire topAnchor property.",
           invalid_type_error: "topAnchor.name must be a string",
         }),
-        url: z.string({
-          required_error:
-            "topAnchor.url is missing, set it or delete the entire topAnchor property.",
-          invalid_type_error: "topAnchor.url must be a string",
-        }),
       },
       {
         invalid_type_error:
-          "topAnchor must be an object with a name and url property. Delete the topAnchor if you don't want to customize the values.",
+          "topAnchor must be an object with a name property. Delete the topAnchor if you don't want to customize the values.",
       }
     )
+    .strict("topAnchor should only have a name property.")
     .optional(),
   anchors: anchorsSchema.optional(),
   footerSocials: footerSocialsSchema.optional(),

--- a/packages/validation/src/schemas/config.ts
+++ b/packages/validation/src/schemas/config.ts
@@ -177,13 +177,18 @@ export const configSchema = z.object({
             "topAnchor.name is missing, set it or delete the entire topAnchor property.",
           invalid_type_error: "topAnchor.name must be a string",
         }),
+        icon: z
+          .string({
+            invalid_type_error: "topAnchor.icon must be a string",
+          })
+          .optional(),
       },
       {
         invalid_type_error:
           "topAnchor must be an object with a name property. Delete the topAnchor if you don't want to customize the values.",
       }
     )
-    .strict("topAnchor should only have a name property.")
+    .strict("topAnchor can only have name and icon properties.")
     .optional(),
   anchors: anchorsSchema.optional(),
   footerSocials: footerSocialsSchema.optional(),


### PR DESCRIPTION
We only use `topAnchor.name` and `topAnchor.icon` to we will remove the other fields from the type.

Also improves the colors schema.