### PR TITLE
[Fix] Use the correct title from config for the title

### DIFF
--- a/client/src/layouts/SupremePageLayout.tsx
+++ b/client/src/layouts/SupremePageLayout.tsx
@@ -53,7 +53,7 @@ export default function SupremePageLayout({
     };
   }, [navIsOpen]);
 
-  const metaTagsDict = getAllMetaTags(pageMetadata, mintConfig.metadata || {});
+  const metaTagsDict = getAllMetaTags(pageMetadata, mintConfig);
 
   return (
     <Intercom appId={mintConfig.integrations?.intercom} autoBoot>

--- a/client/src/utils/getAllMetaTags.ts
+++ b/client/src/utils/getAllMetaTags.ts
@@ -21,13 +21,14 @@ const SEO_META_TAGS = [
   'og:image:height',
 ];
 
-export function getAllMetaTags(pageMeta: PageMetaTags, configMetadata: { [key: string]: any }) {
+export function getAllMetaTags(pageMeta: PageMetaTags, config: { [key: string]: any }) {
+  const configMetadata = config.metadata || {};
   const allMeta = {
     charset: 'utf-8',
     'description': pageMeta.description,
     'og:type': 'website',
-    'og:title': defaultTitle(pageMeta, configMetadata.name),
-    'twitter:title': defaultTitle(pageMeta, configMetadata.name),
+    'og:title': defaultTitle(pageMeta, config.name),
+    'twitter:title': defaultTitle(pageMeta, config.name),
     'og:description': pageMeta.description,
   } as { [key: string]: any };
   SEO_META_TAGS.forEach((tagName) => {


### PR DESCRIPTION
# Summary

There was a configuration where the title was being extracted from the metadata rather than the `name` from the config

# Test Plan

- Run locally on any docs. You should see the title on the tab as `[page_name] - [company name]` e.g `Introduction - Mintlify`