### PR TITLE
Hide quotes added by tailwind-typography

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -59,7 +59,6 @@
     "micromark-extension-gfm": "^2.0.1",
     "micromark-extension-mdx-jsx": "^1.0.3",
     "micromark-extension-mdxjs": "^1.0.0",
-    "mini-svg-data-uri": "^1.4.3",
     "mixpanel-browser": "^2.45.0",
     "next": "^13.0.6",
     "next-mdx-remote": "^4.1.0",

--- a/client/tailwind.config.cjs
+++ b/client/tailwind.config.cjs
@@ -1,5 +1,4 @@
 const defaultTheme = require('tailwindcss/defaultTheme');
-const svgToDataUri = require('mini-svg-data-uri');
 const { default: flattenColorPalette } = require('tailwindcss/lib/util/flattenColorPalette');
 
 module.exports = {
@@ -23,20 +22,7 @@ module.exports = {
       square: '1 / 1',
       video: '16 / 9',
       1: '1',
-      2: '2',
-      3: '3',
-      4: '4',
-      5: '5',
-      6: '6',
-      7: '7',
-      8: '8',
       9: '9',
-      10: '10',
-      11: '11',
-      12: '12',
-      13: '13',
-      14: '14',
-      15: '15',
       16: '16',
     },
     extend: {
@@ -190,13 +176,10 @@ module.exports = {
             'tbody code': {
               fontSize: theme('fontSize.xs')[0],
             },
-            'figure figcaption': {
-              textAlign: 'center',
-              fontStyle: 'italic',
-            },
-            'figure > figcaption': {
-              marginTop: `${12 / 14}em`,
-            },
+
+            // Hide quotes in blockquotes added by tailwind-typography
+            'blockquote p:first-of-type::before': { content: 'none' },
+            'blockquote p:first-of-type::after': { content: 'none' },
           },
         },
         dark: {
@@ -254,23 +237,6 @@ module.exports = {
       maxWidth: {
         '8xl': '92rem',
       },
-      keyframes: {
-        'flash-code': {
-          '0%': { backgroundColor: 'rgb(125 211 252 / 0.1)' },
-          '100%': { backgroundColor: 'transparent' },
-        },
-      },
-      animation: {
-        'flash-code': 'flash-code 1s forwards',
-        'flash-code-slow': 'flash-code 2s forwards',
-      },
-      backgroundImage: (theme) => ({
-        squiggle: `url("${svgToDataUri(
-          `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6 3" enable-background="new 0 0 6 3" width="6" height="3" fill="${theme(
-            'colors.yellow.400'
-          )}"><polygon points="5.5,0 2.5,3 1.1,3 4.1,0"/><polygon points="4,0 6,2 6,0.6 5.4,0"/><polygon points="0,2 1,3 2.4,3 0,0.6"/></svg>`
-        )}")`,
-      }),
     },
   },
   plugins: [
@@ -278,15 +244,7 @@ module.exports = {
     require('@tailwindcss/typography'),
     require('@tailwindcss/aspect-ratio'),
     function ({ addVariant }) {
-      addVariant(
-        'supports-backdrop-blur',
-        '@supports (backdrop-filter: blur(0)) or (-webkit-backdrop-filter: blur(0))'
-      );
-      addVariant('supports-scrollbars', '@supports selector(::-webkit-scrollbar)');
       addVariant('children', '& > *');
-      addVariant('scrollbar', '&::-webkit-scrollbar');
-      addVariant('scrollbar-track', '&::-webkit-scrollbar-track');
-      addVariant('scrollbar-thumb', '&::-webkit-scrollbar-thumb');
     },
     function ({ matchUtilities, theme }) {
       matchUtilities({ values: flattenColorPalette(theme('backgroundColor')), type: 'color' });
@@ -298,7 +256,6 @@ module.exports = {
     'ml-8',
     'ml-12',
     'ml-16',
-    'aspect-video',
     'w-7',
     'h-6',
     'h-7',
@@ -311,5 +268,6 @@ module.exports = {
     'space-x-1',
     'flex-wrap',
     'border-none',
+    'aspect-video',
   ],
 };

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -6956,11 +6956,6 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
-mini-svg-data-uri@^1.4.3:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz#8ab0aabcdf8c29ad5693ca595af19dd2ead09939"
-  integrity sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==
-
 minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"


### PR DESCRIPTION
# Summary

Removes the quotes added to `blockquote` by Tailwind's typography package. Also deletes some Tailwind configurations we are not using anymore.

# Test Plan

Before:

<img width="589" alt="before" src="https://user-images.githubusercontent.com/110702161/211061054-49f8100b-325b-45b5-a569-0ae4c696908e.png">

After:

<img width="584" alt="after" src="https://user-images.githubusercontent.com/110702161/211061158-866ef812-1469-4fad-a741-39aac718ffeb.png">