### PR TITLE
Fix bug to support dynamic API paths

### DIFF
--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -167,7 +167,7 @@ export const extractBaseAndPath = (
   }
 
   const url = new URL(fullEndpoint);
-  const base = url.origin;
+  const base = decodeURI(url.origin);
   const path = fullEndpoint.substring(fullEndpoint.indexOf(base) + base.length);
 
   return {


### PR DESCRIPTION
## Summary

Fixes a bug that allows for the API Base to also be set by path parameters. In the following example, the `domain` can be set using a path param

```
---
api: "POST https://{domain}/api/backend/v1/magic_link"
---

<ParamField path="domain" type="string" required>
  The domain for your application
</ParamField>
```

<img width="1512" alt="CleanShot 2023-01-09 at 22 29 13@2x" src="https://user-images.githubusercontent.com/44352119/211477846-cefb78cf-3243-420d-a37c-b12b64c9ae99.png">

